### PR TITLE
Update docs URL

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -78,7 +78,7 @@ function Footer({ app, host, volume, setting, engineimage, eventlog, dispatch })
         <Col>
           {upgrade}
           <a>{currentVersion}</a>
-          <a target="blank" href="https://github.com/longhorn/longhorn#longhorn">Documentation</a>
+          <a target="blank" href="https://longhorn.io/docs">Documentation</a>
           <a target="blank" onClick={showBundlesModel}>Generate Support Bundle</a>
           <a target="blank" href={issueHref}>File an Issue</a>
           <a target="blank" href="https://slack.cncf.io/">Slack</a>


### PR DESCRIPTION
**NOTE**: do not merge until the new Longhorn docs interface is done.

For now, the https://longhorn.io/docs URL is broken, but once the new Longhorn website is done, the Longhorn docs will be hosted "in house" and that link will go to the rendered Longhorn docs.

You can see a preview here: https://deploy-preview-16--longhornio.netlify.com/docs/.