### PR TITLE
Add support for arm64 (draft)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM nginx:1.16.0
+FROM nginx:1.18.0
 RUN apt-get update -y && \
     apt-get install -y curl \
-                       libcurl3 \
-                       libcurl3-dev \
+                       libcurl4 \
+                       libcurl4-openssl-dev \
                        ngrep \
                        gnupg
 


### PR DESCRIPTION
Addresses partially longhorn/longhorn#6 by adding support for arm64 (armhf not supported).

Update of the base image was needed because `nginx:1.18.0` adds support for arm64.

This PR should be viewed as part of longhorn/longhorn-engine#514.