### PR TITLE
Make nginx listen on IPv6 too

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -10,6 +10,7 @@ http {
         include /etc/nginx/mime.types;
 
         listen 8000;
+        listen [::]:8000;
 
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
Related to: https://github.com/longhorn/longhorn-manager/pull/663

The longhorn-ui nginx's server does not explicitely listen on IPv6. Because of this the longhorn-driver-deployer never becomes available and nothing works.

Cheers