### PR TITLE
Fix readiness status when node is down

### DIFF
--- a/src/routes/host/HostList.js
+++ b/src/routes/host/HostList.js
@@ -164,7 +164,13 @@ class List extends React.Component {
   }
 
   conditionsIsReady = (record) => {
-    return record && record.conditions && record.conditions.Ready && record.conditions.Ready.type === 'Ready'
+    if (record && record.status && record.status.name.toLowerCase() === 'down') {
+      return 'NotReady'
+    } else if (record && record.conditions && record.conditions.Ready && record.conditions.Ready.type === 'Ready') {
+      return 'Ready'
+    } else {
+      return 'Deploying'
+    }
   }
 
   modalBlurOk = () => {
@@ -244,7 +250,7 @@ class List extends React.Component {
         render: (text, record) => {
           return (
             <a style={{ textAlign: 'center', display: 'block' }} onClick={() => { this.showModalBlur(record) }}>
-              {this.conditionsIsReady(record) ? 'Ready' : 'Deploying'}
+              {this.conditionsIsReady(record)}
             </a>
           )
         },


### PR DESCRIPTION
When a node is down, change its Readiness status to NotReady.

![Screenshot-2021-02-18-18:52:40](https://user-images.githubusercontent.com/22583541/108346618-8a4dc200-721a-11eb-8600-af466a261988.png)

https://github.com/longhorn/longhorn/issues/2186#issuecomment-765040722 - 2.
