### PR TITLE
Fix typo, it should be Engine

### DIFF
--- a/src/routes/engineimage/detail/index.js
+++ b/src/routes/engineimage/detail/index.js
@@ -21,7 +21,7 @@ function EngineImageDetail({ engineimage, engineimageId }) {
     <div>
       <Row gutter={24}>
         <Col md={24} xs={24}>
-          <Card title="Enging Image Detail" bordered={false} {...bodyStyle}>
+          <Card title="Engine Image Detail" bordered={false} {...bodyStyle}>
             <EngineImageInfo {...engineImageProps} />
           </Card>
         </Col>


### PR DESCRIPTION
Symptom:
![image](https://user-images.githubusercontent.com/49380831/113087291-eb06ec00-9215-11eb-9f38-437c08f9c19e.png)

Was:`Enging Image Detail`
Is: `Engine Image Detail`
