### PR TITLE
Do not copy Host header to API requests forwarded to Longhorn Manager

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -15,7 +15,6 @@ http {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
         proxy_redirect     off;
-        proxy_set_header   Host             $http_host;
         proxy_set_header   X-Real-IP        $remote_addr;
         proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
         proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;


### PR DESCRIPTION
Longhorn UI serves API requests (/v1/**) via reverse proxy to the Longhorn Manager:

```
location /v1  {
    proxy_pass ${LONGHORN_MANAGER_IP};
    proxy_request_buffering off;
    client_max_body_size 10240M;
}
```

For forwarded requests, the Host header is copied from the original request:

```
proxy_set_header   Host             $http_host;
```

Although the default NGINX behavior is to set Host to the upstream host, overriding this header with the proxy host as longhorn-ui does is not uncommon (it can be useful for constructing absolute URLs that will route via the proxy, for example). However, when Longhorn is deployed in a cluster with a service mesh using Envoy as a sidecar, setting this header breaks routing to Longhorn Manager.

For example, in an Istio mesh, the longhorn-ui sidecar will have a listener configured for routing traffic from longhorn-ui to longhorn-backend (manager) that is based on the longhorn-backend service (i.e., {LONGHORN_BACKEND_CLUSTER_IP}:9500). The listener will support the various hostnames for the service (longhorn-backend, longhorn-backend.longhorn-system, etc.). It will not, however, support the Host used to access the longhorn-ui service. In this scenario, API requests will fail as follows:

 1. API requests arrive at longhorn-ui and match the /v1 location
 2. The Host header value from the inbound request (the Host used to reach longhorn-ui) is copied to the proxied request
 3. DNS lookup for the longhorn-backend service occurs, resolving the service's CLUSTER_IP
 4. The proxied HTTP request is sent to the longhorn-backend CLUSTER_IP with a Host header matching the request received by longhorn-ui (e.g., dashboard.rancher.example.com for Rancher clusters).
 5. The request is intercepted by Envoy and matched to the longhorn-backend service listen based on the destination IP and port.
 6. Envoy is not able to identify a route for the request because the Host header value does not match one of the expected hosts.
 7. Envoy rejects the request with a 404 status code.

This PR reverts the Host header to NGINX's default behavior of setting the Host header to the destination hostname (e.g. longhorn-backend), allowing Envoy to find the appropriate route and forward the request.

Alternatively, X-Forwarded-Host can be used retain information about the host used for original request.

Signed-off-by: Dagan Henderson <dhenderson@goraft.tech>