### PR TITLE
Create a lift config

### DIFF
--- a/.lift/config.toml
+++ b/.lift/config.toml
@@ -1,0 +1,1 @@
+ignoreRules = [ "JSC_PARSE_ERROR" ]


### PR DESCRIPTION
Ignore the useless closure compiler error of JSC_PARSE_ERROR.

We at team lift should ignore this error by default but this project can certainly ignore this or any other error deemed uninteresting with a configuration.