### PR TITLE
Support display instance manager image list

### DIFF
--- a/src/assets/styles/antd-customize/generic.less
+++ b/src/assets/styles/antd-customize/generic.less
@@ -21,22 +21,7 @@
     line-height: 8px !important;
     width: 16px !important;
   }
-  .back-table-class .ant-table-body {
-    height: 3000px;
-  }
-  .volume-table-class .ant-table-body {
-    height: 3000px;
-  }
-  .host-table-class .ant-table-body {
-    height: 3000px;
-  }
-  .backDetail-table-class .ant-table-body {
-    height: 3000px;
-  }
-  .backupImage-table-class .ant-table-body {
-    height: 3000px;
-  }
-  .recurringJob-table-class .ant-table-body {
+  .common-table-class .ant-table-body {
     height: 3000px;
   }
   .ant-table {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import backingImage from './models/backingImage'
 import backup from './models/backup'
 import snapshot from './models/snapshot'
 import recurringJob from './models/recurringJob'
+import instanceManager from './models/instanceManager'
 
 // import assets
 import './assets/iconfont/iconfont.eot'
@@ -34,6 +35,7 @@ app.model(backingImage)
 app.model(backup)
 app.model(volume)
 app.model(recurringJob)
+app.model(instanceManager)
 
 // 3. Router
 app.router(routerConfig)

--- a/src/models/backingImage.js
+++ b/src/models/backingImage.js
@@ -1,9 +1,9 @@
 import { create, deleteBackingImage, query, deleteDisksOnBackingImage, uploadChunk } from '../services/backingImage'
-import { parse } from 'qs'
 import { message, notification } from 'antd'
 import { delay } from 'dva/saga'
 import { wsChanges, updateState } from '../utils/websocket'
 import queryString from 'query-string'
+import { enableQueryData } from '../utils/dataDependency'
 
 export default {
   ws: null,
@@ -26,10 +26,12 @@ export default {
   subscriptions: {
     setup({ dispatch, history }) {
       history.listen(location => {
-        dispatch({
-          type: 'query',
-          payload: location.pathname === '/backingImage' ? queryString.parse(location.search) : '',
-        })
+        if (enableQueryData(location.pathname, 'backingImage')) {
+          dispatch({
+            type: 'query',
+            payload: location.pathname.startsWith('/backingImage') ? queryString.parse(location.search) : {},
+          })
+        }
       })
     },
   },
@@ -37,7 +39,7 @@ export default {
     *query({
       payload,
     }, { call, put }) {
-      const data = yield call(query, parse(payload))
+      const data = yield call(query, payload)
       if (payload && payload.field && payload.keyword && data.data) {
         data.data = data.data.filter(item => item[payload.field] && item[payload.field].indexOf(payload.keyword.trim()) > -1)
       }

--- a/src/models/dashboard.js
+++ b/src/models/dashboard.js
@@ -1,5 +1,6 @@
 import { query } from '../services/dashboard'
-import { parse } from 'qs'
+import queryString from 'query-string'
+import { enableQueryData } from '../utils/dataDependency'
 
 export default {
   namespace: 'dashboard',
@@ -9,10 +10,12 @@ export default {
   subscriptions: {
     setup({ dispatch, history }) {
       history.listen(location => {
-        dispatch({
-          type: 'query',
-          payload: location.query,
-        })
+        if (enableQueryData(location.pathname, 'dashboard')) {
+          dispatch({
+            type: 'query',
+            payload: location.pathname.startsWith('/dashboard') ? queryString.parse(location.search) : {},
+          })
+        }
       })
     },
   },
@@ -20,7 +23,7 @@ export default {
     *query({
       payload,
     }, { call, put }) {
-      const data = yield call(query, parse(payload))
+      const data = yield call(query, payload)
       yield put({ type: 'queryDashboard', payload: { ...data } })
     },
   },

--- a/src/models/engineimage.js
+++ b/src/models/engineimage.js
@@ -1,7 +1,7 @@
 import { create, deleteEngineImage, query } from '../services/engineimage'
 import { wsChanges, updateState } from '../utils/websocket'
-import { parse } from 'qs'
 import queryString from 'query-string'
+import { enableQueryData } from '../utils/dataDependency'
 
 export default {
   ws: null,
@@ -15,10 +15,12 @@ export default {
   subscriptions: {
     setup({ dispatch, history }) {
       history.listen(location => {
-        dispatch({
-          type: 'query',
-          payload: queryString.parse(location.search),
-        })
+        if (enableQueryData(location.pathname, 'engineimage')) {
+          dispatch({
+            type: 'query',
+            payload: location.pathname.startsWith('/engineimage') ? queryString.parse(location.search) : {},
+          })
+        }
       })
     },
   },
@@ -26,7 +28,7 @@ export default {
     *query({
       payload,
     }, { call, put }) {
-      const data = yield call(query, parse(payload))
+      const data = yield call(query, payload)
       if (payload && payload.field && payload.keyword && data.data) {
         data.data = data.data.filter(item => item[payload.field] && item[payload.field].indexOf(payload.keyword.trim()) > -1)
       }

--- a/src/models/eventlog.js
+++ b/src/models/eventlog.js
@@ -1,7 +1,7 @@
 import { query } from '../services/eventlog'
 import { wsChanges, updateState } from '../utils/websocket'
-import { parse } from 'qs'
 import { getSorter, saveSorter } from '../utils/store'
+import { enableQueryData } from '../utils/dataDependency'
 
 export default {
   ws: null,
@@ -14,10 +14,12 @@ export default {
   subscriptions: {
     setup({ dispatch, history }) {
       history.listen(location => {
-        dispatch({
-          type: 'query',
-          payload: location.query,
-        })
+        if (enableQueryData(location.pathname, 'eventlog')) {
+          dispatch({
+            type: 'query',
+            payload: {},
+          })
+        }
       })
     },
   },
@@ -25,7 +27,7 @@ export default {
     *query({
       payload,
     }, { call, put }) {
-      const data = yield call(query, parse(payload))
+      const data = yield call(query, payload)
       yield put({ type: 'queryEventlog', payload: { ...data } })
     },
     *startWS({

--- a/src/models/host.js
+++ b/src/models/host.js
@@ -1,9 +1,9 @@
 import { query, toggleScheduling, updateDisk, deleteHost, getInstancemanagers } from '../services/host'
 import { execAction } from '../services/volume'
 import { wsChanges, updateState } from '../utils/websocket'
-import { parse } from 'qs'
 import { getSorter, saveSorter } from '../utils/store'
 import queryString from 'query-string'
+import { enableQueryData } from '../utils/dataDependency'
 
 export default {
   namespace: 'host',
@@ -32,10 +32,12 @@ export default {
   subscriptions: {
     setup({ dispatch, history }) {
       history.listen(location => {
-        dispatch({
-          type: 'query',
-          payload: queryString.parse(location.search),
-        })
+        if (enableQueryData(location.pathname, 'host')) {
+          dispatch({
+            type: 'query',
+            payload: location.pathname.startsWith('/node') ? queryString.parse(location.search) : {},
+          })
+        }
       })
     },
   },
@@ -43,7 +45,7 @@ export default {
     *query({
       payload,
     }, { call, put }) {
-      const data = yield call(query, parse(payload))
+      const data = yield call(query, payload)
       if (data.data) {
         data.data.sort((a, b) => a.name.localeCompare(b.name))
       }

--- a/src/models/instanceManager.js
+++ b/src/models/instanceManager.js
@@ -1,0 +1,45 @@
+import { query } from '../services/instanceManager'
+import queryString from 'query-string'
+import { enableQueryData } from '../utils/dataDependency'
+
+export default {
+  ws: null,
+  namespace: 'instanceManager',
+  state: {
+    data: [],
+  },
+  subscriptions: {
+    setup({ dispatch, history }) {
+      history.listen(location => {
+        if (enableQueryData(location.pathname, 'instanceManager')) {
+          dispatch({
+            type: 'query',
+            payload: location.pathname.startsWith('/instanceManager') ? queryString.parse(location.search) : {},
+          })
+        }
+      })
+    },
+  },
+  effects: {
+    *query({
+      payload,
+    }, { call, put }) {
+      const data = yield call(query, payload)
+      if (payload && payload.field && payload.value && data.data) {
+        data.data = data.data.filter(item => item[payload.field] && item[payload.field].indexOf(payload.value.trim()) > -1)
+      }
+      if (data.data) {
+        data.data.sort((a, b) => a.name.localeCompare(b.name))
+      }
+      yield put({ type: 'queryInstanceManager', payload: { ...data } })
+    },
+  },
+  reducers: {
+    queryInstanceManager(state, action) {
+      return {
+        ...state,
+        ...action.payload,
+      }
+    },
+  },
+}

--- a/src/models/recurringJob.js
+++ b/src/models/recurringJob.js
@@ -1,7 +1,7 @@
 import { query, create, update, deleteRecurringJob } from '../services/recurringJob'
-import { parse } from 'qs'
 import { wsChanges, updateState } from '../utils/websocket'
 import queryString from 'query-string'
+import { enableQueryData } from '../utils/dataDependency'
 
 export default {
   ws: null,
@@ -14,10 +14,12 @@ export default {
   subscriptions: {
     setup({ dispatch, history }) {
       history.listen(location => {
-        dispatch({
-          type: 'query',
-          payload: location.pathname === '/recurringJob' ? queryString.parse(location.search) : '',
-        })
+        if (enableQueryData(location.pathname, 'recurringJob')) {
+          dispatch({
+            type: 'query',
+            payload: location.pathname.startsWith('/recurringJob') ? queryString.parse(location.search) : {},
+          })
+        }
       })
     },
   },
@@ -25,7 +27,7 @@ export default {
     *query({
       payload,
     }, { call, put }) {
-      const data = yield call(query, parse(payload))
+      const data = yield call(query, payload)
       yield put({ type: 'queryRecurringJob', payload: { ...data } })
     },
     *create({

--- a/src/models/setting.js
+++ b/src/models/setting.js
@@ -1,6 +1,6 @@
 import { query, update } from '../services/setting'
 import { wsChanges, updateState } from '../utils/websocket'
-import { parse } from 'qs'
+import { enableQueryData } from '../utils/dataDependency'
 
 export default {
   ws: null,
@@ -13,10 +13,12 @@ export default {
   subscriptions: {
     setup({ dispatch, history }) {
       history.listen(location => {
-        dispatch({
-          type: 'query',
-          payload: location.query,
-        })
+        if (enableQueryData(location.pathname, 'setting')) {
+          dispatch({
+            type: 'query',
+            payload: {},
+          })
+        }
       })
     },
   },
@@ -24,7 +26,7 @@ export default {
     *query({
       payload,
     }, { call, put }) {
-      const data = yield call(query, parse(payload))
+      const data = yield call(query, payload)
       yield put({ type: 'querySetting', payload: { ...data } })
     },
     *update({ payload }, { call, put, select }) {

--- a/src/models/volume.js
+++ b/src/models/volume.js
@@ -2,10 +2,10 @@ import { create, deleteVolume, query, execAction, createVolumePV, createVolumePV
 import { query as getRecurringJob } from '../services/recurringJob'
 import { wsChanges, updateState } from '../utils/websocket'
 import { sortVolume } from '../utils/sort'
-import { parse } from 'qs'
 import { routerRedux } from 'dva/router'
 import { getSorter, saveSorter } from '../utils/store'
 import queryString from 'query-string'
+import { enableQueryData } from '../utils/dataDependency'
 
 export default {
   namespace: 'volume',
@@ -89,10 +89,10 @@ export default {
   subscriptions: {
     setup({ dispatch, history }) {
       history.listen(location => {
-        if (!location.pathname.endsWith('/backup')) {
+        if (enableQueryData(location.pathname, 'volume')) {
           dispatch({
             type: 'query',
-            payload: queryString.parse(location.search),
+            payload: location.pathname.startsWith('/volume') ? queryString.parse(location.search) : {},
           })
         }
         // Init recurringJobs to empty array
@@ -107,7 +107,7 @@ export default {
     *query({
       payload,
     }, { call, put }) {
-      const data = yield call(query, parse(payload))
+      const data = yield call(query, payload)
       if (payload && payload.field === 'id' && payload.keyword) {
         data.data = data.data.filter(item => item[payload.field].indexOf(payload.keyword) > -1)
       }

--- a/src/publicPath.js
+++ b/src/publicPath.js
@@ -23,6 +23,7 @@ let pageSizeCollectionObject = {
   backupPageSize: 10,
   backupDetailPageSize: 10,
   hostPageSize: 10,
+  instanceManagerSize: 10,
 }
 if (column) {
   columnArr = JSON.parse(column)

--- a/src/router.js
+++ b/src/router.js
@@ -12,6 +12,7 @@ import backupComponent from './routes/backup/'
 import backupDetailComponent from './routes/backup/BackupDetail'
 import settingComponent from './routes/setting/'
 import engineimageComponent from './routes/engineimage/'
+import instanceManagerComponent from './routes/instanceManager/'
 import backingImageComponent from './routes/backingImage/'
 import recurringJobComponent from './routes/recurringJob/'
 import engineimageDetailComponent from './routes/engineimage/detail'
@@ -77,6 +78,11 @@ const Routers = function ({ history, app }) {
     component: () => engineimageDetailComponent,
   })
 
+  const instanceManager = dynamic({
+    app,
+    component: () => instanceManagerComponent,
+  })
+
   const path = '/'
 
   return (
@@ -93,6 +99,7 @@ const Routers = function ({ history, app }) {
             <Route path={`${path}backup/:id`} component={backupDetail} />
             <Route path={`${path}setting`} component={setting} />
             <Route exact path={`${path}engineimage`} component={engineimage} />
+            <Route exact path={`${path}instanceManager`} component={instanceManager} />
             <Route exact path={`${path}backingImage`} component={backingImage} />
             <Route exact path={`${path}recurringJob`} component={recurringJob} />
             <Route path={`${path}engineimage/:id`} component={engineimageDetail} />

--- a/src/routes/backingImage/BackingImageList.js
+++ b/src/routes/backingImage/BackingImageList.js
@@ -73,7 +73,7 @@ function list({ loading, dataSource, deleteBackingImage, cleanUpDiskMap, showDis
   return (
     <div id="backingImageTable" style={{ flex: 1, height: '1px', overflow: 'hidden' }}>
       <Table
-        className="backupImage-table-class"
+        className="common-table-class"
         bordered={false}
         columns={columns}
         rowSelection={rowSelection}

--- a/src/routes/backup/BackupList.js
+++ b/src/routes/backup/BackupList.js
@@ -353,7 +353,7 @@ class List extends React.Component {
     return (
       <div id="backDetailTable" style={{ overflow: 'hidden', flex: 1 }}>
         <Table
-          className="backDetail-table-class"
+          className="common-table-class"
           locale={locale}
           bordered={false}
           columns={columns}

--- a/src/routes/host/HostList.js
+++ b/src/routes/host/HostList.js
@@ -403,7 +403,7 @@ class List extends React.Component {
     return (
       <div id="hostTable" style={{ overflow: 'hidden', flex: 1 }}>
         <Table
-          className="host-table-class"
+          className="common-table-class"
           bordered={false}
           columns={columns}
           dataSource={dataSource}

--- a/src/routes/instanceManager/InstanceManagerList.js
+++ b/src/routes/instanceManager/InstanceManagerList.js
@@ -1,0 +1,136 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Table, Button } from 'antd'
+import { pagination } from '../../utils/page'
+import { sortTable } from '../../utils/sort'
+function list({ loading, dataSource, height, showRefCountVolumeModal }) {
+  const columns = [
+    {
+      title: 'Name',
+      dataIndex: 'name',
+      width: 220,
+      key: 'name',
+      sorter: (a, b) => sortTable(a, b, 'name'),
+      render: (text, record) => {
+        return (
+          <div>
+            <Button type="link" onClick={() => showRefCountVolumeModal(record.volume)}>
+              {text}
+            </Button>
+          </div>
+        )
+      },
+    },
+    {
+      title: 'State',
+      dataIndex: 'currentState',
+      width: 150,
+      key: 'currentState',
+      sorter: (a, b) => sortTable(a, b, 'currentState'),
+      render: (text) => {
+        return (
+          <div className={text === 'running' ? 'healthy' : 'color-warning'}>
+            {text && text.firstUpperCase()}
+          </div>
+        )
+      },
+    },
+    {
+      title: 'Type',
+      dataIndex: 'managerType',
+      width: 150,
+      key: 'managerType',
+      sorter: (a, b) => sortTable(a, b, 'managerType'),
+      render: (text) => {
+        return (
+          <div>
+            {text}
+          </div>
+        )
+      },
+    },
+    {
+      title: 'Ref Count Volume',
+      dataIndex: 'volume',
+      width: 220,
+      key: 'volume',
+      sorter: (a, b) => {
+        if (a.volume && b.volume) {
+          if (a.volume.length > b.volume.length) {
+            return 1
+          }
+          return -1
+        }
+        return 0
+      },
+      render: (text, record) => {
+        return (
+          <div>
+            {record.volume && record.volume.length}
+          </div>
+        )
+      },
+    },
+    {
+      title: 'Node',
+      dataIndex: 'nodeID',
+      width: 150,
+      key: 'nodeID',
+      sorter: (a, b) => sortTable(a, b, 'nodeID'),
+      render: (text) => {
+        return (
+          <div>
+            {text}
+          </div>
+        )
+      },
+    },
+    {
+      title: 'Instance Manager Image',
+      dataIndex: 'image',
+      width: 280,
+      key: 'image',
+      sorter: (a, b) => sortTable(a, b, 'image'),
+      render: (text) => {
+        return (
+          <div>
+            {text}
+          </div>
+        )
+      },
+    },
+  ]
+
+  // dynamic column width
+  let columnWidth = 0
+
+  columns.forEach((ele) => {
+    columnWidth += ele.width
+  })
+
+  return (
+    <div id="instanceManagerTable" style={{ flex: 1, height: '1px', overflow: 'hidden' }}>
+      <Table
+        className="common-table-class"
+        bordered={false}
+        columns={columns}
+        dataSource={dataSource}
+        rowKey={record => record.name}
+        loading={loading}
+        height={`${height}px`}
+        scroll={{ x: columnWidth, y: height }}
+        pagination={pagination('instanceManagerSize')}
+        simple
+      />
+    </div>
+  )
+}
+
+list.propTypes = {
+  loading: PropTypes.bool,
+  dataSource: PropTypes.array,
+  height: PropTypes.number,
+  showRefCountVolumeModal: PropTypes.func,
+}
+
+export default list

--- a/src/routes/instanceManager/RefCountVolumeModal.js
+++ b/src/routes/instanceManager/RefCountVolumeModal.js
@@ -1,0 +1,89 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Table } from 'antd'
+import { sortTable, sortTableByUTCDate } from '../../utils/sort'
+import { pagination } from '../../utils/page'
+import { formatMib } from '../../utils/formater'
+import { formatDate } from '../../utils/formatDate'
+import { ModalBlur } from '../../components'
+import { LinkTo } from '../../components'
+
+const modal = ({
+  visible,
+  onOk,
+  dataSource,
+}) => {
+  const modalOpts = {
+    title: 'Volumes',
+    visible,
+    onOk,
+    onCancel: onOk,
+    hasOnCancel: true,
+    width: 800,
+  }
+  const columns = [
+    {
+      title: 'Name',
+      dataIndex: 'name',
+      key: 'name',
+      sorter: (a, b) => sortTable(a, b, 'name'),
+      render: (text) => {
+        return (
+          <div>
+            <LinkTo to={{ pathname: `/volume/${text}` }}>{text}</LinkTo>
+          </div>
+        )
+      },
+    },
+    {
+      title: 'Size',
+      dataIndex: 'size',
+      key: 'size',
+      sorter: (a, b) => sortTable(a, b, 'size'),
+      render: (text) => {
+        return (
+          <div>
+           {formatMib(text)}
+          </div>
+        )
+      },
+    },
+    {
+      title: 'Created',
+      dataIndex: 'created',
+      key: 'created',
+      sorter: (a, b) => sortTableByUTCDate(a, b, 'created'),
+      render: (text) => {
+        return (
+          <div>
+            {formatDate(text)}
+          </div>
+        )
+      },
+    },
+  ]
+
+  return (
+    <ModalBlur {...modalOpts}>
+      <div style={{ width: '100%', overflow: 'auto', maxHeight: 680 }}>
+        <Table
+          bordered={false}
+          columns={columns}
+          rowKey={record => record.id}
+          dataSource={dataSource}
+          pagination={pagination('volumePageSize')}
+          simple
+        />
+      </div>
+    </ModalBlur>
+  )
+}
+
+modal.propTypes = {
+  visible: PropTypes.bool,
+  dataSource: PropTypes.array,
+  onOk: PropTypes.func,
+  onCancel: PropTypes.func,
+}
+
+export default modal

--- a/src/routes/instanceManager/index.js
+++ b/src/routes/instanceManager/index.js
@@ -1,0 +1,137 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'dva'
+import { Row, Col } from 'antd'
+import { routerRedux } from 'dva/router'
+import queryString from 'query-string'
+import { Filter } from '../../components/index'
+import InstanceManagerList from './InstanceManagerList'
+import RefCountVolumeModal from './RefCountVolumeModal'
+
+class InstanceManager extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      height: 300,
+      refCountVolumeModalVisible: false,
+      refCountVolumeModalKey: Math.random(),
+      refCountVolumeModalDatasource: [],
+    }
+  }
+
+  componentDidMount() {
+    let height = document.getElementById('instanceManagerTable').offsetHeight - 109
+    this.setState({
+      height,
+    })
+    window.onresize = () => {
+      height = document.getElementById('instanceManagerTable').offsetHeight - 109
+      this.setState({
+        height,
+      })
+      this.props.dispatch({ type: 'app/changeNavbar' })
+    }
+  }
+
+  render() {
+    const { loading, location, dispatch, instanceManager, volume } = this.props
+    const instanceManagerData = instanceManager.data
+    const volumeData = volume.data
+    const me = this
+
+    let data = instanceManagerData.map((item) => {
+      item.volume = []
+      if (item.managerType === 'engine') {
+        volumeData.forEach(ele => {
+          if (ele && ele.controllers && ele.controllers[0] && item.name === ele.controllers[0].instanceManagerName) {
+            item.volume.push(ele)
+          }
+        })
+      }
+      if (item.managerType === 'replica') {
+        volumeData.forEach(ele => {
+          if (ele && ele.replicas && ele.replicas.length > 0 && ele.replicas.some((replica) => replica.instanceManagerName === item.name)) {
+            item.volume.push(ele)
+          }
+        })
+      }
+      return item
+    })
+
+    const instanceManagerFilterProps = {
+      location,
+      fieldOption: [
+        { value: 'name', name: 'Name' },
+        { value: 'nodeID', name: 'Node' },
+        { value: 'managerType', name: 'Type' },
+        { value: 'currentState', name: 'State' },
+        { value: 'image', name: 'Instance Manager Image' },
+      ],
+      onSearch(filter) {
+        const { field: filterField, value: filterValue } = filter
+
+        filterField && (filterValue) ? dispatch(routerRedux.push({
+          pathname: '/instanceManager',
+          search: queryString.stringify({
+            ...queryString.parse(location.search),
+            field: filterField,
+            value: filterValue,
+          }),
+        })) : dispatch(routerRedux.push({
+          pathname: '/instanceManager',
+          search: queryString.stringify({}),
+        }))
+      },
+    }
+
+    const InstanceManagerListProps = {
+      dataSource: data,
+      height: this.state.height,
+      loading,
+      showRefCountVolumeModal: (volumes) => {
+        if (volumes) {
+          me.setState({
+            ...me.state,
+            refCountVolumeModalDatasource: volumes,
+            refCountVolumeModalVisible: true,
+          })
+        }
+      },
+    }
+
+    const RefCountVolumeModalProps = {
+      dataSource: this.state.refCountVolumeModalDatasource,
+      visible: this.state.refCountVolumeModalVisible,
+      onOk: () => {
+        me.setState({
+          ...me.state,
+          refCountVolumeModalDatasource: [],
+          refCountVolumeModalVisible: false,
+          refCountVolumeModalKey: Math.random(),
+        })
+      },
+    }
+
+    return (
+      <div className="content-inner" style={{ display: 'flex', flexDirection: 'column', overflow: 'visible !important' }}>
+        <Row gutter={24}>
+          <Col lg={{ offset: 18, span: 6 }} md={{ offset: 16, span: 8 }} sm={24} xs={24} style={{ marginBottom: 16 }}>
+            <Filter {...instanceManagerFilterProps} />
+          </Col>
+        </Row>
+        <InstanceManagerList {...InstanceManagerListProps} />
+        {this.state.refCountVolumeModalVisible && <RefCountVolumeModal key={this.state.refCountVolumeModalKey} {...RefCountVolumeModalProps} />}
+      </div>
+    )
+  }
+}
+
+InstanceManager.propTypes = {
+  instanceManager: PropTypes.object,
+  volume: PropTypes.object,
+  loading: PropTypes.bool,
+  location: PropTypes.object,
+  dispatch: PropTypes.func,
+}
+
+export default connect(({ instanceManager, volume, loading }) => ({ instanceManager, volume, loading: loading.models.engineimage }))(InstanceManager)

--- a/src/routes/recurringJob/RecurringJobList.js
+++ b/src/routes/recurringJob/RecurringJobList.js
@@ -99,7 +99,7 @@ function list({ loading, dataSource, rowSelection, height, deleteRecurringJob, e
   return (
     <div id="recurringJobTable" style={{ flex: 1, height: '1px', overflow: 'hidden' }}>
       <Table
-        className="recurringJob-table-class"
+        className="common-table-class"
         bordered={false}
         columns={columns}
         rowSelection={rowSelection}

--- a/src/routes/volume/VolumeList.js
+++ b/src/routes/volume/VolumeList.js
@@ -406,7 +406,7 @@ function list({ loading, dataSource, engineImages, hosts, showAttachHost, showEn
   return (
     <div id="volumeTable" style={{ flex: 1, height: '1px', overflow: 'hidden' }}>
       <Table
-        className="volume-table-class"
+        className="common-table-class"
         rowSelection={rowSelection}
         bordered={false}
         columns={columns}

--- a/src/routes/volume/index.js
+++ b/src/routes/volume/index.js
@@ -124,12 +124,6 @@ class Volume extends React.Component {
       detached: detachedVolume,
       faulted: faultedVolume,
     }
-    data.forEach(vol => {
-      const found = hosts.find(h => vol.controller && h.id === vol.controller.hostId)
-      if (found) {
-        vol.host = found.name
-      }
-    })
     let volumes = data
     if (field && field === 'status' && volumeFilterMap[stateValue]) {
       volumes = volumeFilterMap[stateValue](volumes)

--- a/src/services/instanceManager.js
+++ b/src/services/instanceManager.js
@@ -1,0 +1,9 @@
+import { request } from '../utils'
+
+export async function query(params) {
+  return request({
+    url: '/v1/instancemanagers',
+    method: 'get',
+    data: params,
+  })
+}

--- a/src/utils/dataDependency.js
+++ b/src/utils/dataDependency.js
@@ -127,6 +127,18 @@ const allWs = [{
   key: 'backups',
 }]
 
+const httpDataDependency = {
+  '/dashboard': ['volume', 'host', 'eventlog'],
+  '/node': ['volume', 'host', 'setting'],
+  '/volume': ['volume', 'host', 'setting', 'backingImage', 'engineimage', 'recurringJob'],
+  '/engineimage': ['engineimage'],
+  '/recurringJob': ['recurringJob'],
+  '/backingImage': ['volume', 'backingImage'],
+  '/setting': ['setting'],
+  '/backup': ['host', 'setting', 'backingImage', 'backup'],
+  '/instanceManager': ['volume', 'instanceManager'],
+}
+
 export function getDataDependency(pathName) {
   let keys = Object.keys(dependency).filter((key) => {
     if (pathName && dependency[key].path) {
@@ -148,4 +160,15 @@ export function getDataDependency(pathName) {
   }
 
   return null
+}
+
+export function enableQueryData(pathName, ns) {
+  let canQueryData = false
+
+  // Determining whether other dependencies model need to request data
+  if (Object.keys(httpDataDependency).some((key) => pathName.startsWith(key) && httpDataDependency[key].find((item) => item === ns)) || pathName === '/') {
+    canQueryData = true
+  }
+
+  return canQueryData
 }

--- a/src/utils/dataDependency.js
+++ b/src/utils/dataDependency.js
@@ -97,6 +97,13 @@ const dependency = {
       key: 'backups',
     }],
   },
+  instanceManager: {
+    path: '/instanceManager',
+    runWs: [{
+      ns: 'volume',
+      key: 'volumes',
+    }],
+  },
 }
 const allWs = [{
   ns: 'volume',

--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -59,6 +59,12 @@ module.exports = [
         name: 'Backing Image',
         icon: 'file-image',
       },
+      {
+        show: true,
+        key: 'instanceManager',
+        name: 'Instance Manager Image',
+        icon: 'apartment',
+      },
     ],
   },
 ]


### PR DESCRIPTION
image: wangsiye/longhorn-ui:398a886

https://github.com/longhorn/longhorn/issues/3306

The pr implements two feature.
1. Load http requests on demand. The original longhorn-ui loads apis with all the data once every time the page is switched. This doesn't make much sense. It should load http requests on demand to reduce the pressure on the server.
2. Support the display of instance manager image list.