### PR TITLE
fix(backingImage) Add uuid to pop-up window

### DIFF
--- a/src/routes/backingImage/DiskStateMapDetail.js
+++ b/src/routes/backingImage/DiskStateMapDetail.js
@@ -138,6 +138,8 @@ const modal = ({
         { !cleanUp ? <div className={style.backingImageModalContainer}>
           <Card>
             <div className={style.parametersContainer} style={{ marginBottom: 0 }}>
+              <div>UUID: </div>
+              <span>{currentData.uuid}</span>
               <div>Created From: </div>
               <span>
                 {currentData.sourceType === 'download' && 'Download from URL'}


### PR DESCRIPTION
https://github.com/longhorn/longhorn/issues/4052

image: wangsiye/longhorn-ui:4552fd8

After discussion with wushuo. Add display of uuid in backingimage's details popup.


<img width="858" alt="截屏2022-06-07 下午4 55 07" src="https://user-images.githubusercontent.com/27733391/172342947-0020bde0-65c8-4595-ba3f-74dc0a90b828.png">

Signed-off-by: Siye Wang <siye@rancher.com>