### PR TITLE
Typo fix: Plase select -> Please select

### DIFF
--- a/src/routes/volume/Salvage.js
+++ b/src/routes/volume/Salvage.js
@@ -142,7 +142,7 @@ class Salvage extends React.Component {
              replicas selected
           </p>
           {
-            this.state.showErrorMessage && this.selectedReplicaNames.length === 0 ? <p className="faulted">Plase select at least one replica.</p> : null
+            this.state.showErrorMessage && this.selectedReplicaNames.length === 0 ? <p className="faulted">Please select at least one replica.</p> : null
           }
         </div>
       </ModalBlur>


### PR DESCRIPTION
Fixes a typo in the Longhorn UI when salvaging a volume.

"Plase select at least one replica."

->

"Please select at least one replica."

Much better ;)