### PR TITLE
ci(upstream): use node:16.16 to fix s390 missing from 16.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as builder
+FROM node:16.16 as builder
 RUN apt-get update -y && \
     apt-get install -y gettext-base
 RUN mkdir /web


### PR DESCRIPTION
ci(upstream): use node:16.16 to fix s390 missing from 16.17

Signed-off-by: David Ko <dko@suse.com>