### PR TITLE
build(image): bump the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ENV VERSION ${VERSION}
 RUN envsubst '${VERSION}' < /web/src/utils/config.js > /web/src/utils/config.js.subst && mv /web/src/utils/config.js.subst /web/src/utils/config.js
 RUN npm run build
 
-FROM registry.suse.com/bci/bci-base:15.3
+FROM registry.suse.com/bci/bci-base:15.4
 
 RUN zypper -n ref && \
 	zypper -n install curl libxml2 bash gettext shadow nginx && \


### PR DESCRIPTION
From SLE BCI 15.3 to 15.4 for security issue

ref: longhorn/longhorn#5107
