### PR TITLE
feat(recurring-job): introduce two task types

### DIFF
--- a/src/routes/recurringJob/CreateRecurringJob.js
+++ b/src/routes/recurringJob/CreateRecurringJob.js
@@ -278,7 +278,9 @@ const modal = ({
             ],
           })(<Select disabled={isEdit} style={{ width: '80%' }} onChange={onChangeTask}>
               <Option value="backup">Backup</Option>
+              <Option value="backup-force-create">Backup Force Create</Option>
               <Option value="snapshot">Snapshot</Option>
+              <Option value="snapshot-force-create">Snapshot Force Create</Option>
               <Option value="snapshot-delete">Snapshot Delete</Option>
               <Option value="snapshot-cleanup">Snapshot Cleanup</Option>
           </Select>)}

--- a/src/routes/volume/detail/CreateRecurringJob.js
+++ b/src/routes/volume/detail/CreateRecurringJob.js
@@ -299,7 +299,9 @@ const modal = ({
                   ],
                 })(<Select disabled={isEdit} style={{ width: '80%' }} onChange={onChangeTask}>
                     <Option value="backup">Backup</Option>
+                    <Option value="backup-force-create">Backup Force Create</Option>
                     <Option value="snapshot">Snapshot</Option>
+                    <Option value="snapshot-force-create">Snapshot Force Create</Option>
                     <Option value="snapshot-delete">Snapshot Delete</Option>
                     <Option value="snapshot-cleanup">Snapshot Cleanup</Option>
                 </Select>)}


### PR DESCRIPTION
Introduce new task types `snapshot-force-create` and `backup-force-create`. They can still take a new snapshot even if old snapshots cleanup failed.

Ref: longhorn/longhorn#4898, longhorn/longhorn#5610