### PR TITLE
Switch to devtool `eval-source-map`

### DIFF
--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -168,7 +168,7 @@ module.exports = {
     fs: "empty",
     module: "empty"
   },
-  devtool: "source-map",
+  devtool: "eval-source-map",
   optimization: {
     splitChunks: {
       cacheGroups: {


### PR DESCRIPTION
Switch to the recommended choice for development builds with high quality source maps. This will simplify debugging in the browser dev tools by providing a 1:1 mapping of the app file structure in the dev tools `Sources` tab.

![Bildschirmfoto vom 2023-04-24 10-28-51](https://user-images.githubusercontent.com/1897962/233941797-f602cee2-a7ed-4756-9245-bcad28c7d5bd.png)
