### PR TITLE
Add hint how to run dev server on a Gnome desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Run development server pointed at some Longhorn Manager API
 ```bash
   LONGHORN_MANAGER_IP="http://longhorn:9500/" npm run dev
 ```
+
+If you are using Gnome as desktop environment, then you should use
+```bash
+  DE=generic LONGHORN_MANAGER_IP="http://longhorn:9500/" npm run dev
+```
+
 Compiling for distribution
 ```bash
   npm run build


### PR DESCRIPTION
This is necessary to fix/workaround this error:
```
Error: Command failed: /home/vot/git/longhorn-ui/node_modules/open/vendor/xdg-open "http://localhost:8080/"
/home/vot/git/longhorn-ui/node_modules/open/vendor/xdg-open: 500: gnome-open: not found
```

Due the fact that all NPM packages are outdated, the NPM `open` package (a dependency of `open-browser-webpack-plugin`) is using command line tools that do not exist anymore (gvfs-open or gnome-open) and were replaced by other tools in latest Gnome versions. To get the dev server running on Gnome it is necessary to set the environment variable `DE` to `generic`.