### PR TITLE
Change origin when using dev server proxy

### DIFF
--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -38,13 +38,13 @@ module.exports = {
       timeout: 10 * 60 * 1000,
       "/v1/ws/**": {
         "target": endpoint,
-        "changeOrigin": false,
+        "changeOrigin": true,
         "ws": true,
         "secure": false
       },
       "/v1/": {
         "target": endpoint,
-        "changeOrigin": false
+        "changeOrigin": true
       },
     }
   },


### PR DESCRIPTION
When connecting to a remote Longhorn-manager instance (e.g. running on Digital Ocean), it is necessary that the proxy changes the origin, otherwise all requests are rejected (404).