### PR TITLE
Use `SourceMapDevToolPlugin` instead of `devtool`

### DIFF
--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -168,7 +168,7 @@ module.exports = {
     fs: "empty",
     module: "empty"
   },
-  devtool: "eval-source-map",
+  devtool: false,
   optimization: {
     splitChunks: {
       cacheGroups: {
@@ -201,6 +201,7 @@ module.exports = {
       }
     ]),
     new webpack.HotModuleReplacementPlugin(),
-    new ManifestPlugin()
+    new ManifestPlugin(),
+    new webpack.SourceMapDevToolPlugin({})
   ]
 };


### PR DESCRIPTION
- Using the plugin will provide the source maps in the browser as expected. `devtool: "source-map"` does not work somehow.
- Prevent `Error: Invalid URL: webpack://[name]_dll/./node_modules/react-router-dom/es/Link.js` errors in browser when using `devtool: "eval-source-map"`.

Replaces: https://github.com/longhorn/longhorn-ui/pull/612

![Bildschirmfoto vom 2023-04-28 11-25-53](https://user-images.githubusercontent.com/1897962/235110343-9aa99ab9-a20e-4228-bbc0-fdfa47d8569a.png)
