### PR TITLE
fix: permission denied when running ui image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ EXPOSE 8000
 ENV LONGHORN_MANAGER_IP http://localhost:9500
 ENV LONGHORN_UI_PORT 8000
 
+RUN mkdir -p /var/config/ && touch /var/run/nginx.pid && chown -R 499 /var/config /var/run/nginx.pid
+
 # Use the uid of the default user (nginx) from the installed nginx package
 USER 499
 


### PR DESCRIPTION
It has a permission denied when running UI image to create tempfs directory, copy nginx config files to tempfs directory and open pid file in /run.
But it could be deployed on k8s cluster.

Ref: longhorn/longhorn#6430