### PR TITLE
Duplicate MIME type "text/html" in /var/config/nginx/nginx.conf

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -4,7 +4,7 @@ http {
         gzip on;
         gzip_min_length 1k;
         gzip_comp_level 2;
-        gzip_types text/html text/plain application/javascript application/x-javascript text/css application/xml text/javascript application/x-httpd-php image/jpeg image/gif image/png image/svg+xml;
+        gzip_types text/plain application/javascript application/x-javascript text/css application/xml text/javascript application/x-httpd-php image/jpeg image/gif image/png image/svg+xml;
         gzip_vary on;
         gzip_disable "MSIE [1-6]\.";
         include /etc/nginx/mime.types;
@@ -42,7 +42,7 @@ http {
         }
 
         location ~ ^/.(images|javascript|js|css|flash|media|static)/ {
-             root /web/dist;       
+             root /web/dist;
         }
 
     }


### PR DESCRIPTION
According to the nginx docs (http://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_types) the MIME type `text/html` does not need to be mentioned.

Fixes: https://github.com/longhorn/longhorn/issues/7002