### PR TITLE
Display AutoEvicting on Node tab while auto evicting

### DIFF
--- a/src/routes/dashboard/components/resourceOverview.js
+++ b/src/routes/dashboard/components/resourceOverview.js
@@ -131,6 +131,7 @@ class ResourceOverview extends React.Component {
       faulted: faultedVolume(volume.data).length,
     }
 
+    // We do not represent autoEvicting in the resource overview. autoEvicting nodes are also unschedulable.
     const nodeInfo = {
       // Total. The total number of nodes.
       total: host.data.length,
@@ -238,6 +239,7 @@ class ResourceOverview extends React.Component {
       },
     }
 
+    // We do not represent autoEvicting in the resource overview. autoEvicting nodes are also unschedulable.
     const nodeInfoColors = [nodeStatusColorMap.schedulable.color, nodeStatusColorMap.unschedulable.color, nodeStatusColorMap.down.color, nodeStatusColorMap.disabled.color]
     const nodeInfoData = [
       { key: 'schedulable', name: 'Schedulable', value: nodeInfo.schedulable },

--- a/src/routes/host/DiskList.js
+++ b/src/routes/host/DiskList.js
@@ -14,7 +14,7 @@ function diskList({ disks, node, storageOverProvisioningPercentage, minimalSched
       return (<span className="disabled">Disabled</span>)
     }
     if (node.conditions && node.conditions.Schedulable && node.conditions.Schedulable.status && node.conditions.Schedulable.status.toLowerCase() === 'false') {
-      return (<span className="disabled">Unschedulable</span>)
+      return (<span className="unschedulable">Unschedulable</span>)
     }
     const status = d.conditions && d.conditions.Schedulable && d.conditions.Schedulable.status && d.conditions.Schedulable.status.toLowerCase() === 'true'
     if (status) {

--- a/src/routes/host/index.js
+++ b/src/routes/host/index.js
@@ -9,7 +9,7 @@ import EditDisk from './EditDisk'
 import HostReplica from './HostReplica'
 import HostFilter from './HostFilter'
 import BulkEditNode from './BulkEditNode'
-import { filterNode, schedulableNode, unschedulableNode, schedulingDisabledNode, downNode, getNodeStatus } from '../../utils/filter'
+import { filterNode, schedulableNode, unschedulableNode, schedulingDisabledNode, downNode, getNodeStatus, autoEvictingNode } from '../../utils/filter'
 
 function Host({ host, volume, setting, loading, dispatch, location }) {
   let hostList = null
@@ -74,6 +74,7 @@ function Host({ host, volume, setting, loading, dispatch, location }) {
   const nodeFilterMap = {
     schedulable: schedulableNode,
     unschedulable: unschedulableNode,
+    autoEvicting: autoEvictingNode,
     schedulingDisabled: schedulingDisabledNode,
     down: downNode,
   }
@@ -321,6 +322,7 @@ function Host({ host, volume, setting, loading, dispatch, location }) {
     stateOption: [
       { value: 'schedulable', name: 'Schedulable' },
       { value: 'unschedulable', name: 'Unschedulable' },
+      { value: 'autoEvicting', name: 'AutoEvicting' },
       { value: 'schedulingDisabled', name: 'Disabled' },
       { value: 'down', name: 'Down' },
     ],


### PR DESCRIPTION
longhorn/longhorn#2238

I originally considered also making AutoEvicting be a separate status from Unschedulable on the Dashboard, but this was too granular of a distinction in my opinion (and the opinion of a couple others I talked to). A user will probably only have one (or a small number) of auto evicting nodes at a time, and the Node tab is a good place to quickly identify it/them.

![2238 Demo](https://github.com/longhorn/longhorn-ui/assets/24213029/52452e0f-5d7c-47ff-9a07-8e6a722a2aa2)
