### PR TITLE
disallows downloading button if disk is not ready

### DIFF
--- a/src/routes/backingImage/BackingImageActions.js
+++ b/src/routes/backingImage/BackingImageActions.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Modal } from 'antd'
 import { DropOption } from '../../components'
+import { hasReadyBackingDisk } from '../../utils/status'
 const confirm = Modal.confirm
 
 function actions({ selected, deleteBackingImage, cleanUpDiskMap, downloadBackingImage }) {
@@ -26,9 +27,11 @@ function actions({ selected, deleteBackingImage, cleanUpDiskMap, downloadBacking
     }
   }
 
+  const disableDownloadAction = !hasReadyBackingDisk(selected)
+
   const availableActions = [
     { key: 'delete', name: 'Delete' },
-    { key: 'download', name: 'Download' },
+    { key: 'download', name: 'Download', disabled: disableDownloadAction, tooltip: disableDownloadAction ? 'Missing disk with ready state' : '' },
     { key: 'cleanUp', name: 'Clean Up' },
   ]
 

--- a/src/utils/status.js
+++ b/src/utils/status.js
@@ -7,3 +7,17 @@ export function statusUpgradingEngine(volume) {
   }
   return ''
 }
+
+/** Check if any of the disk is in a ready state.
+ * @param {*} data v1/backingimages response object.
+ * @returns {boolean} true if any disk is ready.
+ */
+export function hasReadyBackingDisk(data) {
+  try {
+    return Object.keys(data.diskFileStatusMap).some(
+      (key) => data.diskFileStatusMap[key]?.state === 'ready'
+    )
+  } catch (error) {
+    return false
+  }
+}


### PR DESCRIPTION
Ref: https://github.com/longhorn/longhorn/issues/7288

**Changes**:
It will check `diskFileStatusMap` entries and check if any of the disks are in a ready state. if not, the `Download` button will be disabled.

NOTE: please suggest a better tooltip description that fits into the context.

**Screenshoots**
![image](https://github.com/longhorn/longhorn-ui/assets/88777903/f85adad7-7535-4454-b86e-6b3e34828452)
