### PR TITLE
fix(engineimage): use `EngineImage.status.Incompatible`

### DIFF
--- a/src/routes/engineimage/EngineImageList.js
+++ b/src/routes/engineimage/EngineImageList.js
@@ -31,10 +31,10 @@ function list({ loading, dataSource, deleteEngineImage }) {
       dataIndex: 'state',
       key: 'state',
       width: 100,
-      render: (text) => {
+      render: (text, record) => {
         return (
-          <div className={classnames({ [text.toLowerCase()]: true, capitalize: true })}>
-            {text.hyphenToHump()}
+          <div className={classnames({ [record.incompatible ? 'incompatible' : text.toLowerCase()]: true, capitalize: true })}>
+            {record.incompatible ? 'Incompatible' : text.hyphenToHump()}
           </div>
         )
       },

--- a/src/routes/engineimage/detail/EngineImageInfo.js
+++ b/src/routes/engineimage/detail/EngineImageInfo.js
@@ -27,7 +27,7 @@ function EngineImageInfo({ selectedEngineImage }) {
       </div>
       <div className={styles.row}>
         <span className={styles.label}>Status:</span>
-        <span className={classnames({ [selectedEngineImage.state.toLowerCase()]: true, capitalize: true })}>{selectedEngineImage.state.hyphenToHump()}</span>
+        <span className={classnames({ [selectedEngineImage.incompatible ? 'incompatible' : selectedEngineImage.state.toLowerCase()]: true, capitalize: true })}>{selectedEngineImage.incompatible ? 'Incompatible' : selectedEngineImage.state.hyphenToHump()}</span>
       </div>
       <div className={styles.row}>
         <span className={styles.label}>Default:</span>


### PR DESCRIPTION
 Check the EngineImage Status with `.status.incompatible` instead of using `EngineImage.state` directly.

Ref: longhorn/longhorn#7683, longhorn/longhorn#7539