### PR TITLE
Adds better messages for the tooltip

### DIFF
--- a/src/routes/volume/CreateVolume.js
+++ b/src/routes/volume/CreateVolume.js
@@ -331,7 +331,7 @@ const modal = ({
                     </Tooltip>
                   </span>
                 </span>}
-                style={{ paddingLeft: 100 }}
+                style={{ paddingLeft: 93 }}
                 labelCol={{ span: 12 }}
                 wrapperCol={{ span: 12 }}
               >

--- a/src/routes/volume/CreateVolume.js
+++ b/src/routes/volume/CreateVolume.js
@@ -283,11 +283,11 @@ const modal = ({
                   marginLeft: 10,
                   color: '#faad14',
                 }}>
-                  <Tooltip title="A value of 0 will inherit from global settings">
+                  <Tooltip title="Set '0' to inherit global settings">
                     <Icon type="question-circle-o" />
                   </Tooltip>
                 </span>
-                </span>
+              </span>
             }
               style={{ flex: 0.6 }}
               labelCol={{ span: 8 }}
@@ -301,8 +301,14 @@ const modal = ({
                         callback()
                         return
                       }
+                      if (value === 0) {
+                        callback()
+                      }
+                      if (value === 1) {
+                        callback('Set 0 to inherit global settings, or a value from 2 to 250')
+                      }
                       if (value < 2 || value > 250) {
-                        callback('The value should be between 2 and 250')
+                        callback('Set 0 to inherit global settings, or a value from 2 to 250')
                       } else {
                         callback()
                       }
@@ -314,12 +320,18 @@ const modal = ({
             <div style={{ display: 'flex', gap: 10 }}>
               <FormItem
                 label={
+                <span>
+                  Snapshot Max Size
                   <span style={{
+                    marginLeft: 10,
+                    color: '#faad14',
                   }}>
-                    Snapshot Max Size
+                    <Tooltip title="Set '0' for unrestricted size or at least twice volume size">
+                      <Icon type="question-circle-o" />
+                    </Tooltip>
                   </span>
-                }
-                style={{ paddingLeft: 105 }}
+                </span>}
+                style={{ paddingLeft: 100 }}
                 labelCol={{ span: 12 }}
                 wrapperCol={{ span: 12 }}
               >

--- a/src/routes/volume/UpdateSnapshotMaxCountModal.js
+++ b/src/routes/volume/UpdateSnapshotMaxCountModal.js
@@ -57,9 +57,21 @@ const modal = ({
               },
               {
                 validator: (rule, value, callback) => {
-                  if (value < 2 || value > 250 || !/^\d+$/.test(value)) {
+                  if (value === '' || typeof value !== 'number') {
+                    callback()
+                    return
+                  }
+                  if (value === 0) {
+                    callback()
+                  }
+                  if (value === 1) {
                     callback(
-                      'The value should be an integer between 2 and 250'
+                      'Set 0 to inherit global settings, or a value from 2 to 250'
+                    )
+                  }
+                  if (value < 2 || value > 250) {
+                    callback(
+                      'Set 0 to inherit global settings, or a value from 2 to 250'
                     )
                   } else {
                     callback()

--- a/src/routes/volume/UpdateSnapshotMaxCountModal.js
+++ b/src/routes/volume/UpdateSnapshotMaxCountModal.js
@@ -55,29 +55,6 @@ const modal = ({
                 required: true,
                 message: 'Please input volume snapshotMaxCount',
               },
-              {
-                validator: (rule, value, callback) => {
-                  if (value === '' || typeof value !== 'number') {
-                    callback()
-                    return
-                  }
-                  if (value === 0) {
-                    callback()
-                  }
-                  if (value === 1) {
-                    callback(
-                      'Set 0 to inherit global settings, or a value from 2 to 250'
-                    )
-                  }
-                  if (value < 2 || value > 250) {
-                    callback(
-                      'Set 0 to inherit global settings, or a value from 2 to 250'
-                    )
-                  } else {
-                    callback()
-                  }
-                },
-              },
             ],
           })(<InputNumber style={{ width: '270px' }} />)}
         </FormItem>


### PR DESCRIPTION
Ref: https://github.com/longhorn/longhorn/issues/7522

Changes: 
- Improves the tooltip message for `maxCount` so it's clear that 0 means global settings. Fixes the validation so it allows setting 0 back.
- Adds a tooltip for `maxSize` that lets the user know that the size should be at least twice as big as the volume.

![image](https://github.com/longhorn/longhorn-ui/assets/88777903/98848fa4-f952-4ec9-9e8c-7f2746be3168)
![image](https://github.com/longhorn/longhorn-ui/assets/88777903/eba1f6d1-9b3a-4833-a024-9c7b49c586ae)
