### PR TITLE
hides upgrade indicator for v2 volumes

### DIFF
--- a/src/routes/volume/VolumeActions.js
+++ b/src/routes/volume/VolumeActions.js
@@ -199,7 +199,7 @@ function actions({
     { key: 'attach', name: 'Attach', disabled: !attachable(selected) },
     { key: 'detach', name: 'Detach', disabled: !detachable(selected), tooltip: isRwxVolumeWithWorkload() ? 'The volume access mode is `ReadWriteMany`, Please ensure that the workloads are scaled down before trying to detach the volume' : '' },
     { key: 'salvage', name: 'Salvage', disabled: isRestoring(selected) },
-    { key: 'engineUpgrade', name: 'Upgrade Engine', disabled: isAutomaticallyUpgradeEngine() || (engineImages.findIndex(engineImage => selected.engineImage !== engineImage.image) === -1) || isRestoring(selected) || (selected.state !== 'detached' && selected.state !== 'attached') },
+    { key: 'engineUpgrade', name: 'Upgrade Engine', disabled: isAutomaticallyUpgradeEngine() || (engineImages.findIndex(engineImage => selected.engineImage !== engineImage.image) === -1) || isRestoring(selected) || (selected.state !== 'detached' && selected.state !== 'attached') || selected.backendStoreDriver === 'v2' },
     { key: 'updateReplicaCount', name: 'Update Replicas Count', disabled: selected.state !== 'attached' || isRestoring(selected) || selected.standby || upgradingEngine() },
     { key: 'updateDataLocality', name: 'Update Data Locality', disabled: !canUpdateDataLocality() || upgradingEngine() },
     { key: 'updateSnapshotDataIntegrity', name: 'Snapshot Data Integrity', disabled: false },

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -71,6 +71,8 @@ function validReplicas(replicas) {
 }
 
 export function isVolumeImageUpgradable(volume, defaultImage) {
+  if (volume.backendStoreDriver === 'v2') return false
+
   const robustness = volume.robustness.toLowerCase() === 'unknown' ? '' : volume.robustness.hyphenToHump()
   const state = volume.state.toLowerCase()
   return volume.currentImage !== '' && defaultImage && defaultImage.image !== volume.currentImage && ((state === 'attached' && robustness === 'healthy') || (state === 'detached' && robustness !== 'faulted'))


### PR DESCRIPTION
Longhorn_ref: https://github.com/longhorn/longhorn/issues/7863

Hides `Upgrade` icon and action for V2 volumes.