### PR TITLE
Strange placeholder behaviour in input field

### DIFF
--- a/src/routes/backingImage/CreateBackingImage.js
+++ b/src/routes/backingImage/CreateBackingImage.js
@@ -209,7 +209,7 @@ const modal = ({
                 required: false,
               },
             ],
-          })(<Input placeholder="Ask Longhorn to validate the SHA512 checksum if it’s specified here." />)}
+          })(<Input placeholder="Ask Longhorn to validate the SHA512 checksum if it is specified here." />)}
         </FormItem>
       </Form>
     </ModalBlur>


### PR DESCRIPTION
Replace `it’s` with `it is` because the apostrophe is rendered with a big space with the configured `AvenirNext-Regular` font-family. This is the only occurrence of `it’s` in the whole UI, everywhere else `it is` is used. Perhaps for certain reasons.

#### Which issue(s) this PR fixes:
https://github.com/longhorn/longhorn/issues/7917
