### PR TITLE
Show modal to alert users the unsaved change in general settings page

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -63,7 +63,7 @@
         "allowTernary": true
       }
     ],
-    no-plusplus: "off",
+    "no-plusplus": "off",
     "no-continue": "off",
     "arrow-body-style": [
       0,

--- a/src/routes/setting/LeaveSettingsModal.js
+++ b/src/routes/setting/LeaveSettingsModal.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Icon } from 'antd'
+import { ModalBlur } from '../../components'
+
+const modal = ({
+  visible,
+  onCancel,
+  onOk,
+  changedSettings,
+}) => {
+  const modalOpts = {
+    title: 'Leave General Settings ?',
+    visible,
+    onCancel,
+    onOk,
+    okText: 'Leave',
+  }
+
+  return (
+    <ModalBlur {...modalOpts}>
+      <p type="warning">
+        <Icon style={{ marginRight: '10px' }} type="exclamation-circle" />
+        You have unsaved changes below.
+      </p>
+      <ul>
+        {Object.keys(changedSettings).sort().map((key) => (
+          <li key={key}>
+            {`${key}`} : <strong>{`${changedSettings[key]}`}</strong>
+          </li>
+        ))}
+      </ul>
+      <p>Are you sure you want to leave this page?</p>
+    </ModalBlur>
+  )
+}
+
+modal.propTypes = {
+  visible: PropTypes.bool,
+  onCancel: PropTypes.func,
+  onOk: PropTypes.func,
+  changedSettings: PropTypes.object,
+}
+
+export default modal

--- a/src/routes/setting/index.js
+++ b/src/routes/setting/index.js
@@ -28,7 +28,7 @@ class Setting extends React.Component {
     const { confirmedNavigation, changedSettings } = this.state
     const isDirty = Object.keys(changedSettings).length > 0
 
-    if (nextLocation.pathname !== '/settings' && isDirty && !confirmedNavigation) {
+    if (isDirty && !confirmedNavigation) {
       this.showModal(nextLocation)
       return false // disallow navigation
     }
@@ -72,6 +72,13 @@ class Setting extends React.Component {
     }
   }
 
+  resetChangedSettings = () => {
+    this.setState({
+      ...this.state,
+      changedSettings: {},
+    })
+  }
+
   render() {
     const { setting, dispatch, loading } = this.props
     const { modalVisible, changedSettings } = this.state
@@ -87,6 +94,7 @@ class Setting extends React.Component {
           payload,
         })
       },
+      resetChangedSettings: this.resetChangedSettings,
       onInputChange: this.onInputChange,
     }
 

--- a/src/routes/setting/setting.js
+++ b/src/routes/setting/setting.js
@@ -14,7 +14,9 @@ const form = ({
   },
   data,
   saving,
+  loading,
   onSubmit,
+  onInputChange,
 }) => {
   const handleOnSubmit = () => {
     const fields = getFieldsValue()
@@ -39,20 +41,26 @@ const form = ({
     }
   }
   const genInputItem = (setting) => {
+    const settingType = setting.definition.type
+    const settingName = setting.definition.displayName
+
     if (setting.definition && setting.definition.options) {
-      return (<Select getPopupContainer={triggerNode => triggerNode.parentElement}>
-        {setting.definition.options.map((item, index) => {
-          return <Option key={index} value={item}>{item}</Option>
-        })}
-      </Select>)
+      return (
+        <Select onChange={value => onInputChange(settingName, value)} getPopupContainer={triggerNode => triggerNode.parentElement}>
+          {setting.definition.options.map((item, index) => (
+            <Option key={index} value={item}>{item}</Option>
+          ))}
+        </Select>
+      )
     }
-    switch (setting.definition.type) {
+
+    switch (settingType) {
       case 'bool':
-        return (<Checkbox disabled={setting.definition.readOnly} />)
+        return (<Checkbox disabled={setting.definition.readOnly} onChange={e => onInputChange(settingName, e.target.checked)} />)
       case 'int':
-        return (<InputNumber style={{ width: '100%' }} parser={limitNumber} disabled={setting.definition.readOnly} min={0} />)
+        return (<InputNumber onChange={value => onInputChange(settingName, value)} style={{ width: '100%' }} parser={limitNumber} disabled={setting.definition.readOnly} min={0} />)
       default:
-        return (<Input readOnly={setting.definition.readOnly} />)
+        return (<Input readOnly={setting.definition.readOnly} onChange={e => onInputChange(settingName, e.target.value)} />)
     }
   }
   const genFormItem = (setting) => {
@@ -94,6 +102,7 @@ const form = ({
       </FormItem>
     )
   }
+
   const getCategoryWeight = (category) => {
     switch (category) {
       case 'general':
@@ -128,22 +137,32 @@ const form = ({
       return 1
     }
     return 0
-  }).map(item => <div key={item}> <div className={classnames(styles.fieldset, { [styles.dangerZone]: item === 'danger Zone' })}><span className={styles.fieldsetLabel}>{item}</span> { settingsGrouped[item].map(setting => genFormItem(setting))}</div></div>)
+  }).map(item => (
+    <div key={item}>
+      <div className={classnames(styles.fieldset, { [styles.dangerZone]: item === 'danger Zone' })}>
+        <span className={styles.fieldsetLabel}>{item}</span>
+        {settingsGrouped[item].map(setting => genFormItem(setting))}
+      </div>
+    </div>
+  ))
 
   return (
-    <Spin spinning={saving}>
-      {<Form className={styles.setting}>
+    <Spin spinning={saving || loading}>
+      <Form className={styles.setting}>
         {settings}
-        <FormItem style={{ textAlign: 'center' }}>
-          <Button
-            onClick={handleOnSubmit}
-            loading={saving}
-            type="primary"
-            htmlType="submit">
-            Save
-          </Button>
-        </FormItem>
-      </Form>}
+      </Form>
+       {settings.length > 0 && (
+          <div style={{ textAlign: 'center', position: 'sticky', marginTop: '1rem' }}>
+            <Button
+              onClick={handleOnSubmit}
+              loading={saving}
+              type="primary"
+              htmlType="submit"
+            >
+              Save
+            </Button>
+          </div>
+       )}
     </Spin>
   )
 }
@@ -154,6 +173,7 @@ form.propTypes = {
   onSubmit: PropTypes.func,
   saving: PropTypes.bool,
   loading: PropTypes.bool,
+  onInputChange: PropTypes.func,
 }
 
 export default Form.create()(form)

--- a/src/routes/setting/setting.js
+++ b/src/routes/setting/setting.js
@@ -17,11 +17,13 @@ const form = ({
   loading,
   onSubmit,
   onInputChange,
+  resetChangedSettings,
 }) => {
   const handleOnSubmit = () => {
     const fields = getFieldsValue()
     Object.keys(fields).forEach(key => { fields[key] = fields[key].toString() })
     onSubmit(fields)
+    resetChangedSettings()
   }
   const parseSettingRules = (setting) => {
     const definition = setting.definition
@@ -147,7 +149,7 @@ const form = ({
   ))
 
   return (
-    <Spin spinning={saving || loading}>
+    <Spin spinning={saving || loading} style={{ height: '100vh' }}>
       <Form className={styles.setting}>
         {settings}
       </Form>
@@ -174,6 +176,7 @@ form.propTypes = {
   saving: PropTypes.bool,
   loading: PropTypes.bool,
   onInputChange: PropTypes.func,
+  resetChangedSettings: PropTypes.func,
 }
 
 export default Form.create()(form)

--- a/src/routes/setting/setting.less
+++ b/src/routes/setting/setting.less
@@ -1,4 +1,7 @@
 .setting {
+  max-height: 78vh;
+  overflow-y: auto;
+
   :global .ant-input-group-addon {
     text-transform: capitalize;
   }
@@ -24,4 +27,8 @@
   .dangerZone {
     border: 1px solid #f15354;
   }
+}
+
+:global .ant-spin-nested-loading{
+  height: 100vh;
 }

--- a/src/routes/setting/setting.less
+++ b/src/routes/setting/setting.less
@@ -28,7 +28,3 @@
     border: 1px solid #f15354;
   }
 }
-
-:global .ant-spin-nested-loading{
-  height: 100vh;
-}


### PR DESCRIPTION
Current general settings page are too long that users easily forget to "save" the settings change before leaving this page.

This PR 
- sticky save button at the bottom
- show modal to alert users there are some unsaved changes when changing the route.

issus : https://github.com/longhorn/longhorn/issues/7497


https://github.com/longhorn/longhorn-ui/assets/5744158/f6cb381d-6b7c-4ebf-86a9-4c81e7c7c831


