### PR TITLE
fix: update code spell skip items

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,4 +18,4 @@ jobs:
       uses: codespell-project/actions-codespell@v2
       with:
         check_filenames: true
-        skip: "*/**.yaml,*/**.yml,./scripts,./vendor,MAINTAINERS,LICENSE,go.mod,go.sum,**/*-lock.json,**/*.svg"
+        skip: "*/**.yaml,*/**.yml,./scripts,./vendor,MAINTAINERS,LICENSE,*-lock.json,**/*.svg,"


### PR DESCRIPTION
Some bot dependency update PRs are blocked by Code spell check for package-lock.json.
- https://github.com/longhorn/longhorn-ui/pull/717
- https://github.com/longhorn/longhorn-ui/pull/717

This PR updates code spell skip item since there is no Golang used in this repo.  