### PR TITLE
fine tune the save button layout in settings page

### DIFF
--- a/src/routes/setting/setting.js
+++ b/src/routes/setting/setting.js
@@ -150,21 +150,23 @@ const form = ({
 
   return (
     <Spin spinning={saving || loading} style={{ height: '100vh' }}>
-      <Form className={styles.setting}>
-        {settings}
-      </Form>
-       {settings.length > 0 && (
-          <div style={{ textAlign: 'center', position: 'sticky', marginTop: '1rem' }}>
-            <Button
-              onClick={handleOnSubmit}
-              loading={saving}
-              type="primary"
-              htmlType="submit"
-            >
-              Save
-            </Button>
-          </div>
-       )}
+      <div className={styles.wrapper}>
+        <Form className={styles.setting}>
+          {settings}
+        </Form>
+        {settings.length > 0 && (
+            <div style={{ textAlign: 'center', position: 'sticky', marginTop: '1rem' }}>
+              <Button
+                onClick={handleOnSubmit}
+                loading={saving}
+                type="primary"
+                htmlType="submit"
+              >
+                Save
+              </Button>
+            </div>
+        )}
+       </div>
     </Spin>
   )
 }

--- a/src/routes/setting/setting.less
+++ b/src/routes/setting/setting.less
@@ -1,30 +1,37 @@
-.setting {
-  max-height: 78vh;
-  overflow-y: auto;
+.wrapper{
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 200px);
 
-  :global .ant-input-group-addon {
-    text-transform: capitalize;
-  }
-  .fieldset {
-    border: 1px solid #f2f4f5;
-    position: relative;
-    margin: 24px 0px;
-    padding: 16px 16px 0 16px;
-    > .fieldsetLabel {
-      position: absolute;
-      transform: translateY(-120%);
+  .setting {
+    max-height: fit-content;
+    overflow-y: auto;
+
+    :global .ant-input-group-addon {
       text-transform: capitalize;
-      display: inline-block;
-      padding: 0 24px;
-      white-space: nowrap;
-      text-align: center;
-      font-weight: 700;
-      color: rgb(173, 172, 172);
-      font-size: 18px;
-      background-color: #ffffff;
+    }
+    .fieldset {
+      border: 1px solid #f2f4f5;
+      position: relative;
+      margin: 24px 0px;
+      padding: 16px 16px 0 16px;
+      > .fieldsetLabel {
+        position: absolute;
+        transform: translateY(-120%);
+        text-transform: capitalize;
+        display: inline-block;
+        padding: 0 24px;
+        white-space: nowrap;
+        text-align: center;
+        font-weight: 700;
+        color: rgb(173, 172, 172);
+        font-size: 18px;
+        background-color: #ffffff;
+      }
+    }
+    .dangerZone {
+      border: 1px solid #f15354;
     }
   }
-  .dangerZone {
-    border: 1px solid #f15354;
-  }
 }
+


### PR DESCRIPTION
### Goal  
Fine tune the save button layout in settings page to make it `significant visible` in any browser zoom ratio or small screen.

### Issue
https://github.com/longhorn/longhorn/issues/7497

My [previous PR](https://github.com/longhorn/longhorn-ui/pull/721) sticky the save button at the buttom of page. 

But it will be unvisible if user zoom into bigger browser ratio (e.g. 100%). This PR makes button all visible to any zoom ratio.

<img width="1496" alt="Screenshot 2024-05-08 at 11 11 39 AM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/65ba3771-3644-4d0b-a405-e7784bf4a373">



### Test Result
#### zoom out to 67%
<img width="1490" alt="Screenshot 2024-05-08 at 11 22 35 AM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/b2cd1d51-c255-4f4a-b437-1080565c8f3c">

#### Zoom in to 133%

<img width="1494" alt="Screenshot 2024-05-08 at 11 22 45 AM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/b0595555-2c57-4b5b-8f0a-9b62c86b5c22">
 
#### In small screen

<img width="1488" alt="Screenshot 2024-05-08 at 11 23 13 AM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/9868bab9-9036-4435-b9c3-2278d3862787">

