### PR TITLE
Correct original empty string won't trigger unsaved modal

### DIFF
--- a/src/routes/setting/index.js
+++ b/src/routes/setting/index.js
@@ -50,7 +50,7 @@ class Setting extends React.Component {
   onInputChange = (displayName, newValue) => {
     const { setting: { data } } = this.props
     const targetSettingOldValue = data.find(d => d.definition.displayName === displayName)?.value
-    if (targetSettingOldValue && targetSettingOldValue.toString() !== newValue.toString()) {
+    if (targetSettingOldValue !== undefined && targetSettingOldValue.toString() !== newValue.toString()) {
       this.setState(prevState => ({
         changedSettings: {
           ...prevState.changedSettings,


### PR DESCRIPTION
Fix defect found by QA: https://github.com/longhorn/longhorn/issues/7497#issuecomment-2102212463

if `targetSettingOldValue` is empty string or zero, the original logic won't record the unsaved change.

After fix

https://github.com/longhorn/longhorn-ui/assets/5744158/8e1449c8-2618-4f86-998e-dc267000c45e

 

