### PR TITLE
Allow download mulitple backing images with one click and move clean up action in detail modal

### DIFF
--- a/src/models/backingImage.js
+++ b/src/models/backingImage.js
@@ -13,7 +13,6 @@ export default {
     resourceType: 'backingImage',
     selected: {},
     selectedRows: [],
-    cleanUp: false,
     createBackingImageModalVisible: false,
     createBackingImageModalKey: Math.random(),
     diskStateMapDetailModalVisible: false,
@@ -196,10 +195,15 @@ export default {
       return { ...state, createBackingImageModalVisible: false }
     },
     showDiskStateMapDetailModal(state, action) {
-      return { ...state, selected: action.payload.record, cleanUp: action.payload.cleanUp, diskStateMapDetailModalVisible: true, diskStateMapDetailModalKey: Math.random() }
+      return {
+        ...state,
+        selected: action.payload.record,
+        diskStateMapDetailModalVisible: true,
+        diskStateMapDetailModalKey: Math.random(),
+      }
     },
     hideDiskStateMapDetailModal(state) {
-      return { ...state, diskStateMapDetailModalVisible: false, cleanUp: false, diskStateMapDetailModalKey: Math.random() }
+      return { ...state, diskStateMapDetailModalVisible: false, diskStateMapDetailModalKey: Math.random() }
     },
     disableDiskStateMapDelete(state) {
       return { ...state, diskStateMapDeleteDisabled: true }

--- a/src/models/backingImage.js
+++ b/src/models/backingImage.js
@@ -1,4 +1,4 @@
-import { create, deleteBackingImage, query, deleteDisksOnBackingImage, uploadChunk, download } from '../services/backingImage'
+import { create, deleteBackingImage, query, deleteDisksOnBackingImage, uploadChunk, download, bulkDownload } from '../services/backingImage'
 import { message, notification } from 'antd'
 import { delay } from 'dva/saga'
 import { wsChanges, updateState } from '../utils/websocket'
@@ -101,6 +101,13 @@ export default {
     }, { call, put }) {
       yield call(download, payload)
       yield put({ type: 'query' })
+    },
+    *bulkDownload({
+      payload,
+    }, { call }) {
+      if (payload && payload.length > 0) {
+        yield call(bulkDownload, payload)
+      }
     },
     *bulkDelete({
       payload,

--- a/src/routes/backingImage/BackingImageActions.js
+++ b/src/routes/backingImage/BackingImageActions.js
@@ -5,7 +5,7 @@ import { DropOption } from '../../components'
 import { hasReadyBackingDisk } from '../../utils/status'
 const confirm = Modal.confirm
 
-function actions({ selected, deleteBackingImage, cleanUpDiskMap, downloadBackingImage }) {
+function actions({ selected, deleteBackingImage, downloadBackingImage }) {
   const handleMenuClick = (event, record) => {
     event.domEvent?.stopPropagation?.()
     switch (event.key) {
@@ -20,9 +20,6 @@ function actions({ selected, deleteBackingImage, cleanUpDiskMap, downloadBacking
       case 'download':
         downloadBackingImage(record)
         break
-      case 'cleanUp':
-        cleanUpDiskMap(record)
-        break
       default:
     }
   }
@@ -32,7 +29,6 @@ function actions({ selected, deleteBackingImage, cleanUpDiskMap, downloadBacking
   const availableActions = [
     { key: 'delete', name: 'Delete' },
     { key: 'download', name: 'Download', disabled: disableDownloadAction, tooltip: disableDownloadAction ? 'Missing disk with ready state' : '' },
-    { key: 'cleanUp', name: 'Clean Up' },
   ]
 
   return (
@@ -45,7 +41,6 @@ function actions({ selected, deleteBackingImage, cleanUpDiskMap, downloadBacking
 actions.propTypes = {
   selected: PropTypes.object,
   deleteBackingImage: PropTypes.func,
-  cleanUpDiskMap: PropTypes.func,
   downloadBackingImage: PropTypes.func,
 }
 

--- a/src/routes/backingImage/BackingImageBulkActions.js
+++ b/src/routes/backingImage/BackingImageBulkActions.js
@@ -42,11 +42,11 @@ function bulkActions({ selectedRows, deleteBackingImages, downloadSelectedBackin
           okText: 'Download',
           width: 'fit-content',
           title: (<>
-                    <p>Below <strong style={readyTextStyle}>Ready</strong> status Backing {count === 1 ? 'Image' : 'Images' } will be downloaded.</p>
+                    <p>Below backing {count === 1 ? 'image' : 'images' } with <strong style={readyTextStyle}>Ready</strong> status disk will be downloaded</p>
                     <ul>
                       {downloadableImages.map(item => <li>{item.name}</li>)}
                     </ul>
-                    <p>Note. You need allow <strong>Automatic Download</strong> permission<br />in browser settings to download multiple files at once.</p>
+                    <p>Note. You need allow <strong>Automatic Downloads</strong> permission<br />in browser settings to download multiple files at once.</p>
                   </>),
           onOk() {
             downloadSelectedBackingImages(downloadableImages)

--- a/src/routes/backingImage/BackingImageList.js
+++ b/src/routes/backingImage/BackingImageList.js
@@ -5,10 +5,9 @@ import BackingImageActions from './BackingImageActions'
 import { pagination } from '../../utils/page'
 import { formatMib } from '../../utils/formatter'
 
-function list({ loading, dataSource, deleteBackingImage, cleanUpDiskMap, showDiskStateMapDetail, rowSelection, downloadBackingImage, height }) {
+function list({ loading, dataSource, deleteBackingImage, showDiskStateMapDetail, rowSelection, downloadBackingImage, height }) {
   const backingImageActionsProps = {
     deleteBackingImage,
-    cleanUpDiskMap,
     downloadBackingImage,
   }
   const state = (record) => {
@@ -28,6 +27,7 @@ function list({ loading, dataSource, deleteBackingImage, cleanUpDiskMap, showDis
       dataIndex: 'name',
       key: 'name',
       width: 200,
+      sorter: (a, b) => a.name.localeCompare(b.name),
       render: (text, record) => {
         return (
           <div onClick={() => { showDiskStateMapDetail(record) }} style={{ width: '100%', cursor: 'pointer' }}>
@@ -40,6 +40,7 @@ function list({ loading, dataSource, deleteBackingImage, cleanUpDiskMap, showDis
       dataIndex: 'uuid',
       key: 'uuid',
       width: 150,
+      sorter: (a, b) => a.uuid.localeCompare(b.uuid),
       render: (text) => {
         return (
           <div>{text}</div>
@@ -50,6 +51,7 @@ function list({ loading, dataSource, deleteBackingImage, cleanUpDiskMap, showDis
       dataIndex: 'size',
       key: 'size',
       width: 150,
+      sorter: (a, b) => a.size - b.size,
       render: (text) => {
         return (
           <div>
@@ -62,6 +64,7 @@ function list({ loading, dataSource, deleteBackingImage, cleanUpDiskMap, showDis
       dataIndex: 'sourceType',
       key: 'sourceType',
       width: 200,
+      sorter: (a, b) => a.sourceType.localeCompare(b.sourceType),
       render: (text) => {
         return (
           <div>
@@ -104,7 +107,6 @@ list.propTypes = {
   dataSource: PropTypes.array,
   deleteBackingImage: PropTypes.func,
   showDiskStateMapDetail: PropTypes.func,
-  cleanUpDiskMap: PropTypes.func,
   rowSelection: PropTypes.object,
   height: PropTypes.number,
 }

--- a/src/routes/backingImage/DiskStateMapActions.js
+++ b/src/routes/backingImage/DiskStateMapActions.js
@@ -6,7 +6,7 @@ const confirm = Modal.confirm
 function DiskStateMapActions({ selectedRows, deleteButtonDisabled, deleteButtonLoading, deleteDisksOnBackingImage }) {
   const deleteButtonClick = () => {
     confirm({
-      title: `Are you sure to delete the image files from the disks (${selectedRows.map(item => item.disk).join(',')}) ?`,
+      title: `Are you sure to clean up the image file from the disks (${selectedRows.map(item => item.disk).join(',')}) ?`,
       onOk() {
         deleteDisksOnBackingImage(selectedRows)
       },
@@ -21,7 +21,7 @@ function DiskStateMapActions({ selectedRows, deleteButtonDisabled, deleteButtonL
   }
 
   return (
-    <Button {...deleteButtonProps}>Delete</Button>
+    <Button {...deleteButtonProps}>Clean Up</Button>
   )
 }
 

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -68,7 +68,7 @@ class BackingImage extends React.Component {
     const { dispatch, loading, location } = this.props
     const { uploadFile } = this
     const { data: volumeData } = this.props.volume
-    const { data, selected, createBackingImageModalVisible, createBackingImageModalKey, diskStateMapDetailModalVisible, diskStateMapDetailModalKey, diskStateMapDeleteDisabled, diskStateMapDeleteLoading, selectedDiskStateMapRows, selectedDiskStateMapRowKeys, selectedRows, cleanUp } = this.props.backingImage
+    const { data, selected, createBackingImageModalVisible, createBackingImageModalKey, diskStateMapDetailModalVisible, diskStateMapDetailModalKey, diskStateMapDeleteDisabled, diskStateMapDeleteLoading, selectedDiskStateMapRows, selectedDiskStateMapRowKeys, selectedRows } = this.props.backingImage
     const { backingImageUploadPercent, backingImageUploadStarted } = this.props.app
     const { field, value } = queryString.parse(this.props.location.search)
     let backingImages = data.filter((item) => {
@@ -91,12 +91,6 @@ class BackingImage extends React.Component {
           payload: record,
         })
       },
-      cleanUpDiskMap(record) {
-        dispatch({
-          type: 'backingImage/showDiskStateMapDetailModal',
-          payload: { record, cleanUp: true },
-        })
-      },
       downloadBackingImage(record) {
         dispatch({
           type: 'backingImage/downloadBackingImage',
@@ -106,7 +100,7 @@ class BackingImage extends React.Component {
       showDiskStateMapDetail(record) {
         dispatch({
           type: 'backingImage/showDiskStateMapDetailModal',
-          payload: { record, cleanUp: false },
+          payload: { record },
         })
       },
       rowSelection: {
@@ -190,7 +184,6 @@ class BackingImage extends React.Component {
     const diskStateMapDetailModalProps = {
       selected,
       backingImages,
-      cleanUp,
       visible: diskStateMapDetailModalVisible,
       onCancel: () => {
         dispatch({ type: 'backingImage/hideDiskStateMapDetailModal' })

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -264,6 +264,12 @@ class BackingImage extends React.Component {
           payload: record,
         })
       },
+      downloadSelectedBackingImages(record) {
+        dispatch({
+          type: 'backingImage/bulkDownload',
+          payload: record,
+        })
+      },
     }
 
     let inUploadProgress = backingImageUploadStarted

--- a/src/services/backingImage.js
+++ b/src/services/backingImage.js
@@ -28,9 +28,21 @@ export async function deleteBackingImage(params) {
   }
 }
 
+export async function bulkDownload(images) {
+  for (const image of images) {
+    if (image?.name) {
+      // eslint-disable-next-line no-underscore-dangle
+      const downloadUrl = `${window.__pathname_prefix__}${window.__pathname_prefix__.endsWith('/') ? '' : '/'}v1/backingimages/${image.name}/download`
+      // specific way to download multiple files with one click, User may allow the browser to download multiple files at once
+      Object.assign(document.createElement('a'), { href: downloadUrl, download: image.name }).click()
+    }
+  }
+}
+
 export async function download(params) {
   if (params && params.name) {
-    window.location.href = `${ window.__pathname_prefix__ }${ window.__pathname_prefix__.endsWith('/') ? '' : '/'}v1/backingimages/${params.name}/download` // eslint-disable-line
+    // eslint-disable-next-line no-underscore-dangle
+    window.location.href = `${window.__pathname_prefix__}${window.__pathname_prefix__.endsWith('/') ? '' : '/'}v1/backingimages/${params.name}/download`
   }
 }
 

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -26,6 +26,14 @@ const isAutoEvicting = (node) => node.conditions && node.conditions.Ready && nod
 const isDisabled = (node) => node.conditions && node.conditions.Ready && node.conditions.Ready.status.toLowerCase() === 'true'
                                              && (node.allowScheduling === false || Object.values(node.disks).every(d => d.allowScheduling === false))
 const isDown = (node) => node.conditions && node.conditions.Ready && node.conditions.Ready.status.toLowerCase() === 'false'
+
+export const diskStatusColorMap = {
+  ready: { color: '#27AE5F', bg: 'rgba(39,174,95,.05)' }, // green
+  'in-progress': { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
+  'ready-for-transfer': { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
+  'failed-and-cleanup': { color: '#F15354', bg: 'rgba(241,83,84,.05)' }, // red
+}
+
 export const nodeStatusColorMap = {
   schedulable: { color: '#27AE5F', bg: 'rgba(39,174,95,.05)' },
   unschedulable: { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' },


### PR DESCRIPTION
## Goal 
 - Allow user to sort the backing image list
 - Add bulk download button to allow user download mutliple backing images at once
 - Remove disk cleanup action in operation dropdown and move into detail modal 

## Issue
https://github.com/longhorn/longhorn/issues/7293
 

## Result
Sort the backing image list
**![sort](https://github.com/longhorn/longhorn-ui/assets/5744158/18922098-0bcd-4abb-89d8-a70bb077a621)**


Bulk download
![d](https://github.com/longhorn/longhorn-ui/assets/5744158/2c995b05-dbe3-4665-9522-065754a694ae)


Move cleanup action in detail modal
![clean](https://github.com/longhorn/longhorn-ui/assets/5744158/612500d4-fad9-42d6-ba9a-bd5c2b79e738)




