### PR TITLE
Filter out non-ready status backing images in volume create modal dropdown

### DIFF
--- a/src/routes/backingImage/DiskStateMapDetail.js
+++ b/src/routes/backingImage/DiskStateMapDetail.js
@@ -88,7 +88,7 @@ const modal = ({
               </Tooltip>
             )}
             <Tooltip title={record.message}>
-              {text ? (
+              {text && (
                 <div
                   style={{
                     display: 'inline-block',
@@ -101,8 +101,9 @@ const modal = ({
                     textTransform: 'capitalize',
                   }}
                 >{text}</div>
-              ) : <Icon type="sync" style={{ color: '#0077ea' }} spin />}
-              {record.message ? <Icon type="message" className="color-warning" /> : ''}
+              )}
+              {record.message && <Icon type="message" className="color-warning" />}
+              {!text && !record.message && <Icon type="sync" style={{ color: '#0077ea' }} spin />}
             </Tooltip>
           </div>
         )

--- a/src/routes/volume/index.js
+++ b/src/routes/volume/index.js
@@ -59,6 +59,7 @@ import {
 } from './helper'
 import { healthyVolume, inProgressVolume, degradedVolume, detachedVolume, faultedVolume, filterVolume, isVolumeImageUpgradable, isVolumeSchedule } from '../../utils/filter'
 import C from '../../utils/constants'
+import { hasReadyBackingDisk } from '../../utils/status'
 
 const confirm = Modal.confirm
 
@@ -761,7 +762,7 @@ class Volume extends React.Component {
       v1DataEngineEnabled,
       v2DataEngineEnabled,
       diskTags,
-      backingImages,
+      backingImages: backingImages?.filter(image => hasReadyBackingDisk(image)) || [],
       tagsLoading,
       hosts,
       visible: createVolumeModalVisible,

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -29,9 +29,12 @@ const isDown = (node) => node.conditions && node.conditions.Ready && node.condit
 
 export const diskStatusColorMap = {
   ready: { color: '#27AE5F', bg: 'rgba(39,174,95,.05)' }, // green
+  starting: { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
+  pending: { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
   'in-progress': { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
   'ready-for-transfer': { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
   'failed-and-cleanup': { color: '#F15354', bg: 'rgba(241,83,84,.05)' }, // red
+  failed: { color: '#F15354', bg: 'rgba(241,83,84,.05)' }, // red
 }
 
 export const nodeStatusColorMap = {


### PR DESCRIPTION
## Goal
- Filter out non-ready status backing image in volume create modal dropdown
- Add more backing images disk state colors

## Issue 
Implement extra improvement based on discussion [[IMPROVEMENT] BackingImage UI improvement](https://github.com/longhorn/longhorn/issues/7293#issuecomment-2134688954)
 

## Result

<img width="1485" alt="Screenshot 2024-05-29 at 12 38 27 PM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/fccf4423-453f-44c4-ad44-dc46ab05c34f">

Only let user choose `READY` status backing images

<img width="660" alt="Screenshot 2024-05-29 at 12 38 57 PM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/668cb6ee-7af9-4e1c-90a7-01957e51ccaa">
