### PR TITLE
Update backing image clean up disk wordings and modal style

### DIFF
--- a/src/routes/backingImage/DiskStateMapActions.js
+++ b/src/routes/backingImage/DiskStateMapActions.js
@@ -6,7 +6,15 @@ const confirm = Modal.confirm
 function DiskStateMapActions({ selectedRows, deleteButtonDisabled, deleteButtonLoading, deleteDisksOnBackingImage }) {
   const deleteButtonClick = () => {
     confirm({
-      title: `Are you sure to clean up the image file from the disks (${selectedRows.map(item => item.disk).join(',')}) ?`,
+      width: 'fit-content',
+      title: (
+          <>
+            <p>Are you sure you want to remove the image file from the disks ?</p>
+            <ul>
+              {selectedRows.map(item => <li>{item.disk}</li>)}
+            </ul>
+          </>
+      ),
       onOk() {
         deleteDisksOnBackingImage(selectedRows)
       },


### PR DESCRIPTION
## What's change in this PR ?
Update backing image clean up disk wordings and modal style  (from writer [suggestion comment](https://github.com/longhorn/website/pull/913#issuecomment-2141440408))

## Related Issue
[[IMPROVEMENT] BackingImage UI improvement](https://github.com/longhorn/longhorn/issues/7293)

## Test Result
<img width="1483" alt="Screenshot 2024-06-03 at 11 54 09 AM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/3d84e01b-d795-4c8a-9431-9aade8fac2e4">
