### PR TITLE
Introduce longhorn UI version env variable in webpack

### DIFF
--- a/src/routes/setting/setting.js
+++ b/src/routes/setting/setting.js
@@ -4,6 +4,8 @@ import ReactMarkdown from 'react-markdown/with-html'
 import { Form, Input, Button, Spin, Icon, Checkbox, Select, InputNumber, Alert } from 'antd'
 import styles from './setting.less'
 import { classnames } from '../../utils'
+import { LH_UI_VERSION } from '../../utils/constants'
+
 const FormItem = Form.Item
 const { Option } = Select
 
@@ -158,7 +160,7 @@ const form = ({
             message={
             <div className={styles.description}>
               <span>
-              Some <a target="blank" href="https://longhorn.io/docs/1.6.2/references/settings/#danger-zone">Danger Zone settings</a> are not immediately applied when one or more volumes are still attached. Ensure that all volumes are detached before configuring the settings.
+              Some <a target="blank" href={`https://longhorn.io/docs/${LH_UI_VERSION}/references/settings/#danger-zone`}>Danger Zone settings</a> are not immediately applied when one or more volumes are still attached. Ensure that all volumes are detached before configuring the settings.
               </span>
               {unAppliedDangerZoneSettings.length > 0 && (
                 <>

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,3 +1,5 @@
+const { LH_UI_VERSION } = process.env
+
 const C = {
   RegExp: {
     // Regular expressions ensure that only the correct request path is included
@@ -7,3 +9,4 @@ const C = {
 }
 
 export default C
+export { LH_UI_VERSION }

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -11,7 +11,8 @@ const ProgressBarPlugin = require('progress-bar-webpack-plugin');
 const OpenBrowserPlugin = require('open-browser-webpack-plugin');
 var FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const endpoint = process.env.LONGHORN_MANAGER_IP || 'http://54.223.25.181:9500/';
-
+const versionText = require('fs').readFileSync('./version', 'utf8');
+const longhornVersion = versionText ? versionText.trim().substring(1).split('-')[0]: '1.7.0';
 
 module.exports = {
   entry: path.resolve(__dirname, "src", "index.js"),
@@ -182,6 +183,11 @@ module.exports = {
     }
   },
   plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        LH_UI_VERSION: JSON.stringify(longhornVersion),
+      }
+    }),
     new OpenBrowserPlugin({url: 'http://localhost:8080/'}),
     new ProgressBarPlugin(),
     new FriendlyErrorsWebpackPlugin(),

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -15,7 +15,8 @@ const os = require("os");
 const happyThreadPool = HappyPack.ThreadPool({ size: os.cpus().length });
 
 const theme = require("./src/theme");
-
+const versionText = require('fs').readFileSync('./version', 'utf8');
+const longhornVersion = versionText ? versionText.trim().substring(1).split('-')[0]: '1.7.0';
 
 module.exports = {
   devtool: 'source-map',
@@ -152,6 +153,11 @@ module.exports = {
     runtimeChunk: true
   },
   plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        LH_UI_VERSION: JSON.stringify(longhornVersion),
+      }
+    }),
     new ProgressBarPlugin(),
     new ManifestPlugin(),
     new MiniCssExtractPlugin({


### PR DESCRIPTION
## What's change in this PR?
From this [PR comment](https://github.com/longhorn/longhorn-ui/pull/735#discussion_r1623752344), we need to let user link to correct version docs following to LH UI version.

Introduce env variable in webpack to know longhorn-ui version at build time.(npm run dev & npm run build)

## Issue
https://github.com/longhorn/longhorn/issues/8071

## Test Result

**Development mode**

<img width="1488" alt="Screenshot 2024-06-03 at 4 09 54 PM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/bea359a4-627a-403c-90b1-6356d99bc194">


v1.6.3 (by updating version file)

<img width="1496" alt="Screenshot 2024-06-03 at 5 26 24 PM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/d5f6d897-ed62-4ae1-baad-0c007c0276c7">

v1.7.0

<img width="1439" alt="Screenshot 2024-06-03 at 5 24 40 PM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/87b911e6-9b8b-47f0-8849-0c4f37f79b38">

--------------------------------------------------------------------------------------------------------------------

**Production mode**

<img width="1011" alt="Screenshot 2024-06-03 at 4 31 29 PM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/d3f0bd75-091b-4270-8520-85c7e20dbd79">


Local run `make build` and `make run` to run up longhorn-ui build image

<img width="957" alt="Screenshot 2024-06-04 at 11 06 39 AM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/2c5e8e06-7742-4a4d-97f7-3d9c8ac8b6c1">

