### PR TITLE
Correct makefile typo and add make enter command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ VERSION = $(shell ./scripts/version)
 REPO = longhornio
 NAME = longhorn-ui
 INSTANCE = default
-LONHORN_MANAGER_IP = http://localhost:9500
+LONGHORN_MANAGER_IP = http://localhost:9500
 PORT = 8000
 IMAGE = $(REPO)/$(NAME):$(VERSION)
 
 BASE_IMAGE = $(shell grep FROM Dockerfile | grep -vi ' AS ' | awk '{print $$2}' )
 
-.PHONY: build push shell run start stop rm release
+.PHONY: build push shell run start stop rm release enter
 
 build:
 	# update base image to get latest changes
@@ -24,5 +24,8 @@ stop:
 
 run:
 	docker run -d --name $(NAME)-$(INSTANCE) -p $(PORT):8000 -e LONGHORN_MANAGER_IP=$(LONGHORN_MANAGER_IP) $(REPO)/$(NAME):$(VERSION)
+
+enter:
+	docker exec -it $(NAME)-$(INSTANCE) /bin/bash
 
 default: build

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Prerequisites:
 
 Setup:
 ```bash
-  git clone 'https://github.com/rancher/longhorn-ui'
+  git clone 'https://github.com/longhorn/longhorn-ui'
   cd 'longhorn-ui'
   npm ci
 ```
@@ -31,7 +31,7 @@ Compiling for distribution
   npm run build
 ```
 
-Build and run a docker image
+Build and run a docker image, longhorn UI will listen on localhost:8000
 ```bash
   make
   make LONGHORN_MANAGER_IP=http://longhorn:9500 run


### PR DESCRIPTION
## What's change in this PR

- fix makefile typo 
- add make enter command
- update REDAM.md

## Test Result
Run below commands on my Macbook

- make build : build longhorn-ui image from Dockerfile
- make run :  run up docker container listening on localhost 8000
- make enter : enter container shell



<img width="1424" alt="Screenshot 2024-06-04 at 11 08 32 AM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/4e8027a0-7a89-4c7d-ad41-2b0a76953946">

<img width="1496" alt="Screenshot 2024-06-04 at 11 08 25 AM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/953aa802-38ef-4590-a702-6f84d1b6b820">