### PR TITLE
Add Apply All button and encrypted option in Create DR volume bulk action

### DIFF
--- a/src/routes/backup/CreateStandbyVolumeModal.js
+++ b/src/routes/backup/CreateStandbyVolumeModal.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Form, Input, InputNumber, Select, Spin, Alert, Popover } from 'antd'
+import { Form, Input, InputNumber, Select, Spin, Checkbox, Alert, Popover } from 'antd'
 import { ModalBlur } from '../../components'
 import { formatMib } from '../../utils/formatter'
 
@@ -166,6 +166,12 @@ const modal = ({
           })(<Select disabled>
             { backingImages.map(backingImage => <Option key={backingImage.name} value={backingImage.name}>{backingImage.name}</Option>) }
           </Select>)}
+        </FormItem>
+        <FormItem label="Encrypted" {...formItemLayout}>
+        {getFieldDecorator('encrypted', {
+          valuePropName: 'encrypted',
+          initialValue: false,
+        })(<Checkbox />)}
         </FormItem>
         <Spin spinning={tagsLoading}>
           <FormItem label="Node Tag" hasFeedback {...formItemLayout}>

--- a/src/routes/backup/RestoreBackupModal.js
+++ b/src/routes/backup/RestoreBackupModal.js
@@ -50,6 +50,7 @@ const modal = ({
       onOk(data)
     })
   }
+
   const modalOpts = {
     title: `Restore Backup ${item.backupName}`,
     visible,
@@ -140,6 +141,12 @@ const modal = ({
           })(<Select allowClear={true} disabled>
             { backingImages.map(backingImage => <Option key={backingImage.name} value={backingImage.name}>{backingImage.name}</Option>) }
           </Select>)}
+        </FormItem>
+        <FormItem label="Encrypted" {...formItemLayout}>
+        {getFieldDecorator('encrypted', {
+          valuePropName: 'encrypted',
+          initialValue: false,
+        })(<Checkbox></Checkbox>)}
         </FormItem>
         <FormItem label="Restore Volume Recurring Job" hasFeedback {...formItemLayout}>
           {getFieldDecorator('restoreVolumeRecurringJob', {

--- a/src/routes/backup/index.js
+++ b/src/routes/backup/index.js
@@ -250,7 +250,7 @@ function Backup({ backup, loading, setting, backingImage, dispatch, location }) 
       numberOfReplicas: defaultNumberOfReplicas,
       size,
       fromBackup: lastBackupUrl,
-      name: `dr-${volumeName}`,
+      name: volumeName,
       backingImage: currentBackupVolume?.backingImageName || '',
     },
     visible: createVolumeStandModalVisible,


### PR DESCRIPTION
## What's this PR change

Based on the demo feedback, change
- Remove previous & next buttons. Instead add `Apply All` button for one-click to apply current config to all the others
- Add `encypted option` in Create DR volume bulk action ([discuss thread](https://suse.slack.com/archives/C02DR3N5T24/p1717650221226099?thread_ts=1717649231.597089&cid=C02DR3N5T24))
- Still allow user to click each tab to fill in the restore volume config / DR config

## Issue

[[IMPROVEMENT] Restore Latest Backup should be applied with BackingImage name value](https://github.com/longhorn/longhorn/issues/7560)

## Result

`Restore Latest Backup`

https://github.com/longhorn/longhorn-ui/assets/5744158/fa3103aa-b247-4536-b515-96dcefedacb5


`Create Disaster Recovery Volume`

![create_DR](https://github.com/longhorn/longhorn-ui/assets/5744158/90d8b70b-0143-4ae9-be51-ff03c20848b0)


