### PR TITLE
[BACKPORT][v1.6.3] BackingImage UI improvement (backport mulitple PRs)

### DIFF
--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -9,7 +9,7 @@ const Option = Select.Option
 class Filter extends React.Component {
   constructor(props) {
     super(props)
-    const { field = props.defaultField || 'name', value = '', stateValue = '', nodeRedundancyValue = '', engineImageUpgradableValue = '', scheduleValue = '', pvStatusValue = '', revisionCounterValue = '', isGroupValue = '' } = queryString.parse(props.location.search)
+    const { field = props.defaultField || 'name', value = '', stateValue = '', nodeRedundancyValue = '', engineImageUpgradableValue = '', scheduleValue = '', pvStatusValue = '', revisionCounterValue = '', isGroupValue = '', createdFromValue = '' } = queryString.parse(props.location.search)
     this.state = {
       field,
       stateValue,
@@ -19,6 +19,7 @@ class Filter extends React.Component {
       scheduleValue,
       pvStatusValue,
       revisionCounterValue,
+      createdFromValue,
       isGroupValue,
       keyword: value,
     }
@@ -63,12 +64,16 @@ class Filter extends React.Component {
     this.setState({ ...this.state, isGroupValue })
   }
 
+  handleCreatedFromValueChange = (createdFromValue) => {
+    this.setState({ ...this.state, createdFromValue })
+  }
+
   handleFieldChange = (field) => {
     this.setState({ ...this.state, field })
   }
 
   render() {
-    const { field = this.props.defaultField || 'name', value = '', stateValue = '', nodeRedundancyValue = '', engineImageUpgradableValue = '', scheduleValue = '', pvStatusValue = '', revisionCounterValue = '', isGroup = '' } = queryString.parse(this.props.location.search)
+    const { field = this.props.defaultField || 'name', value = '', stateValue = '', nodeRedundancyValue = '', engineImageUpgradableValue = '', scheduleValue = '', pvStatusValue = '', revisionCounterValue = '', isGroup = '', createdFromValue = '' } = queryString.parse(this.props.location.search)
 
     let defaultContent = {
       field,
@@ -79,6 +84,7 @@ class Filter extends React.Component {
       scheduleValue,
       pvStatusValue,
       revisionCounterValue,
+      createdFromValue,
       isGroup,
     }
 
@@ -153,22 +159,32 @@ class Filter extends React.Component {
     >
     {this.props.revisionCounterOption.map(item => (<Option key={item.value} value={item.value}>{item.name}</Option>))}
     </Select>)
+    } else if (this.state.field === 'sourceType' && this.props.createdFromOption) {
+      valueForm = (<Select key="sourceType"
+        style={{ width: '100%' }}
+        size="large"
+        allowClear
+        defaultValue={this.state.createdFromValue}
+        onChange={this.handleCreatedFromValueChange}
+    >
+    {this.props.createdFromOption.map(item => (<Option key={item.value} value={item.value}>{item.name}</Option>))}
+    </Select>)
     }
 
     let content = ''
-    let popoverVsible = false
+    let popoverVisible = false
 
     for (let key in defaultContent) {
       if (defaultContent[key] !== '' && key !== 'field' && this.state[key] !== defaultContent[key]) {
         content = (<div style={{ maxWidth: '200px', wordBreak: 'break-word' }}>{`Current Filter: ${defaultContent[key]}`}</div>)
-        popoverVsible = true
+        popoverVisible = true
       }
     }
 
     return (
       <Form>
       <Input.Group compact className={styles.filter}>
-      <Popover placement="topLeft" content={content} visible={popoverVsible}>
+      <Popover placement="topLeft" content={content} visible={popoverVisible}>
         <Select size="large" defaultValue={this.state.field} className={styles.filterSelect} onChange={this.handleFieldChange}>
           {this.props.fieldOption.map(item => (<Option key={item.value} value={item.value}>{item.name}</Option>))}
         </Select>
@@ -194,6 +210,7 @@ Filter.propTypes = {
   pvStatusOption: PropTypes.array,
   revisionCounterOption: PropTypes.array,
   recurringJobIsGroupOption: PropTypes.array,
+  createdFromOption: PropTypes.array,
 }
 
 export default Filter

--- a/src/models/backingImage.js
+++ b/src/models/backingImage.js
@@ -13,7 +13,6 @@ export default {
     resourceType: 'backingImage',
     selected: {},
     selectedRows: [],
-    cleanUp: false,
     createBackingImageModalVisible: false,
     createBackingImageModalKey: Math.random(),
     diskStateMapDetailModalVisible: false,
@@ -196,10 +195,15 @@ export default {
       return { ...state, createBackingImageModalVisible: false }
     },
     showDiskStateMapDetailModal(state, action) {
-      return { ...state, selected: action.payload.record, cleanUp: action.payload.cleanUp, diskStateMapDetailModalVisible: true, diskStateMapDetailModalKey: Math.random() }
+      return {
+        ...state,
+        selected: action.payload.record,
+        diskStateMapDetailModalVisible: true,
+        diskStateMapDetailModalKey: Math.random(),
+      }
     },
     hideDiskStateMapDetailModal(state) {
-      return { ...state, diskStateMapDetailModalVisible: false, cleanUp: false, diskStateMapDetailModalKey: Math.random() }
+      return { ...state, diskStateMapDetailModalVisible: false, diskStateMapDetailModalKey: Math.random() }
     },
     disableDiskStateMapDelete(state) {
       return { ...state, diskStateMapDeleteDisabled: true }

--- a/src/models/backingImage.js
+++ b/src/models/backingImage.js
@@ -1,4 +1,4 @@
-import { create, deleteBackingImage, query, deleteDisksOnBackingImage, uploadChunk, download } from '../services/backingImage'
+import { create, deleteBackingImage, query, deleteDisksOnBackingImage, uploadChunk, download, bulkDownload } from '../services/backingImage'
 import { message, notification } from 'antd'
 import { delay } from 'dva/saga'
 import { wsChanges, updateState } from '../utils/websocket'
@@ -101,6 +101,13 @@ export default {
     }, { call, put }) {
       yield call(download, payload)
       yield put({ type: 'query' })
+    },
+    *bulkDownload({
+      payload,
+    }, { call }) {
+      if (payload && payload.length > 0) {
+        yield call(bulkDownload, payload)
+      }
     },
     *bulkDelete({
       payload,

--- a/src/routes/backingImage/BackingImage.less
+++ b/src/routes/backingImage/BackingImage.less
@@ -8,7 +8,7 @@
   }
   .parametersContainer {
     margin-bottom: 10px;
-    display: grid; 
+    display: grid;
     grid-template-columns: 36% 63%;
     grid-row-gap: 15px;
     div {

--- a/src/routes/backingImage/BackingImageActions.js
+++ b/src/routes/backingImage/BackingImageActions.js
@@ -5,7 +5,7 @@ import { DropOption } from '../../components'
 import { hasReadyBackingDisk } from '../../utils/status'
 const confirm = Modal.confirm
 
-function actions({ selected, deleteBackingImage, cleanUpDiskMap, downloadBackingImage }) {
+function actions({ selected, deleteBackingImage, downloadBackingImage }) {
   const handleMenuClick = (event, record) => {
     event.domEvent?.stopPropagation?.()
     switch (event.key) {
@@ -20,9 +20,6 @@ function actions({ selected, deleteBackingImage, cleanUpDiskMap, downloadBacking
       case 'download':
         downloadBackingImage(record)
         break
-      case 'cleanUp':
-        cleanUpDiskMap(record)
-        break
       default:
     }
   }
@@ -32,7 +29,6 @@ function actions({ selected, deleteBackingImage, cleanUpDiskMap, downloadBacking
   const availableActions = [
     { key: 'delete', name: 'Delete' },
     { key: 'download', name: 'Download', disabled: disableDownloadAction, tooltip: disableDownloadAction ? 'Missing disk with ready state' : '' },
-    { key: 'cleanUp', name: 'Clean Up' },
   ]
 
   return (
@@ -45,7 +41,6 @@ function actions({ selected, deleteBackingImage, cleanUpDiskMap, downloadBacking
 actions.propTypes = {
   selected: PropTypes.object,
   deleteBackingImage: PropTypes.func,
-  cleanUpDiskMap: PropTypes.func,
   downloadBackingImage: PropTypes.func,
 }
 

--- a/src/routes/backingImage/BackingImageBulkActions.js
+++ b/src/routes/backingImage/BackingImageBulkActions.js
@@ -42,11 +42,11 @@ function bulkActions({ selectedRows, deleteBackingImages, downloadSelectedBackin
           okText: 'Download',
           width: 'fit-content',
           title: (<>
-                    <p>Below <strong style={readyTextStyle}>Ready</strong> status Backing {count === 1 ? 'Image' : 'Images' } will be downloaded.</p>
+                    <p>Below backing {count === 1 ? 'image' : 'images' } with <strong style={readyTextStyle}>Ready</strong> status disk will be downloaded</p>
                     <ul>
                       {downloadableImages.map(item => <li>{item.name}</li>)}
                     </ul>
-                    <p>Note. You need allow <strong>Automatic Download</strong> permission<br />in browser settings to download multiple files at once.</p>
+                    <p>Note. You need allow <strong>Automatic Downloads</strong> permission<br />in browser settings to download multiple files at once.</p>
                   </>),
           onOk() {
             downloadSelectedBackingImages(downloadableImages)

--- a/src/routes/backingImage/BackingImageList.js
+++ b/src/routes/backingImage/BackingImageList.js
@@ -5,10 +5,9 @@ import BackingImageActions from './BackingImageActions'
 import { pagination } from '../../utils/page'
 import { formatMib } from '../../utils/formater'
 
-function list({ loading, dataSource, deleteBackingImage, cleanUpDiskMap, showDiskStateMapDetail, rowSelection, downloadBackingImage, height }) {
+function list({ loading, dataSource, deleteBackingImage, showDiskStateMapDetail, rowSelection, downloadBackingImage, height }) {
   const backingImageActionsProps = {
     deleteBackingImage,
-    cleanUpDiskMap,
     downloadBackingImage,
   }
   const state = (record) => {
@@ -28,6 +27,7 @@ function list({ loading, dataSource, deleteBackingImage, cleanUpDiskMap, showDis
       dataIndex: 'name',
       key: 'name',
       width: 200,
+      sorter: (a, b) => a.name.localeCompare(b.name),
       render: (text, record) => {
         return (
           <div onClick={() => { showDiskStateMapDetail(record) }} style={{ width: '100%', cursor: 'pointer' }}>
@@ -40,6 +40,7 @@ function list({ loading, dataSource, deleteBackingImage, cleanUpDiskMap, showDis
       dataIndex: 'uuid',
       key: 'uuid',
       width: 150,
+      sorter: (a, b) => a.uuid.localeCompare(b.uuid),
       render: (text) => {
         return (
           <div>{text}</div>
@@ -50,6 +51,7 @@ function list({ loading, dataSource, deleteBackingImage, cleanUpDiskMap, showDis
       dataIndex: 'size',
       key: 'size',
       width: 150,
+      sorter: (a, b) => a.size - b.size,
       render: (text) => {
         return (
           <div>
@@ -62,6 +64,7 @@ function list({ loading, dataSource, deleteBackingImage, cleanUpDiskMap, showDis
       dataIndex: 'sourceType',
       key: 'sourceType',
       width: 200,
+      sorter: (a, b) => a.sourceType.localeCompare(b.sourceType),
       render: (text) => {
         return (
           <div>
@@ -104,7 +107,6 @@ list.propTypes = {
   dataSource: PropTypes.array,
   deleteBackingImage: PropTypes.func,
   showDiskStateMapDetail: PropTypes.func,
-  cleanUpDiskMap: PropTypes.func,
   rowSelection: PropTypes.object,
   height: PropTypes.number,
 }

--- a/src/routes/backingImage/DiskStateMapActions.js
+++ b/src/routes/backingImage/DiskStateMapActions.js
@@ -6,7 +6,7 @@ const confirm = Modal.confirm
 function DiskStateMapActions({ selectedRows, deleteButtonDisabled, deleteButtonLoading, deleteDisksOnBackingImage }) {
   const deleteButtonClick = () => {
     confirm({
-      title: `Are you sure to delete the image files from the disks (${selectedRows.map(item => item.disk).join(',')}) ?`,
+      title: `Are you sure to clean up the image file from the disks (${selectedRows.map(item => item.disk).join(',')}) ?`,
       onOk() {
         deleteDisksOnBackingImage(selectedRows)
       },
@@ -21,7 +21,7 @@ function DiskStateMapActions({ selectedRows, deleteButtonDisabled, deleteButtonL
   }
 
   return (
-    <Button {...deleteButtonProps}>Delete</Button>
+    <Button {...deleteButtonProps}>Clean Up</Button>
   )
 }
 

--- a/src/routes/backingImage/DiskStateMapActions.js
+++ b/src/routes/backingImage/DiskStateMapActions.js
@@ -6,7 +6,15 @@ const confirm = Modal.confirm
 function DiskStateMapActions({ selectedRows, deleteButtonDisabled, deleteButtonLoading, deleteDisksOnBackingImage }) {
   const deleteButtonClick = () => {
     confirm({
-      title: `Are you sure to clean up the image file from the disks (${selectedRows.map(item => item.disk).join(',')}) ?`,
+      width: 'fit-content',
+      title: (
+          <>
+            <p>Are you sure you want to remove the image file from the disks ?</p>
+            <ul>
+              {selectedRows.map(item => <li>{item.disk}</li>)}
+            </ul>
+          </>
+      ),
       onOk() {
         deleteDisksOnBackingImage(selectedRows)
       },

--- a/src/routes/backingImage/DiskStateMapDetail.js
+++ b/src/routes/backingImage/DiskStateMapDetail.js
@@ -88,7 +88,7 @@ const modal = ({
               </Tooltip>
             )}
             <Tooltip title={record.message}>
-              {text ? (
+              {text && (
                 <div
                   style={{
                     display: 'inline-block',
@@ -101,8 +101,9 @@ const modal = ({
                     textTransform: 'capitalize',
                   }}
                 >{text}</div>
-              ) : <Icon type="sync" style={{ color: '#0077ea' }} spin />}
-              {record.message ? <Icon type="message" className="color-warning" /> : ''}
+              )}
+              {record.message && <Icon type="message" className="color-warning" />}
+              {!text && !record.message && <Icon type="sync" style={{ color: '#0077ea' }} spin />}
             </Tooltip>
           </div>
         )

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -68,7 +68,7 @@ class BackingImage extends React.Component {
     const { dispatch, loading, location } = this.props
     const { uploadFile } = this
     const { data: volumeData } = this.props.volume
-    const { data, selected, createBackingImageModalVisible, createBackingImageModalKey, diskStateMapDetailModalVisible, diskStateMapDetailModalKey, diskStateMapDeleteDisabled, diskStateMapDeleteLoading, selectedDiskStateMapRows, selectedDiskStateMapRowKeys, selectedRows, cleanUp } = this.props.backingImage
+    const { data, selected, createBackingImageModalVisible, createBackingImageModalKey, diskStateMapDetailModalVisible, diskStateMapDetailModalKey, diskStateMapDeleteDisabled, diskStateMapDeleteLoading, selectedDiskStateMapRows, selectedDiskStateMapRowKeys, selectedRows } = this.props.backingImage
     const { backingImageUploadPercent, backingImageUploadStarted } = this.props.app
     const { field, value } = queryString.parse(this.props.location.search)
     let backingImages = data.filter((item) => {
@@ -91,12 +91,6 @@ class BackingImage extends React.Component {
           payload: record,
         })
       },
-      cleanUpDiskMap(record) {
-        dispatch({
-          type: 'backingImage/showDiskStateMapDetailModal',
-          payload: { record, cleanUp: true },
-        })
-      },
       downloadBackingImage(record) {
         dispatch({
           type: 'backingImage/downloadBackingImage',
@@ -106,7 +100,7 @@ class BackingImage extends React.Component {
       showDiskStateMapDetail(record) {
         dispatch({
           type: 'backingImage/showDiskStateMapDetailModal',
-          payload: { record, cleanUp: false },
+          payload: { record },
         })
       },
       rowSelection: {
@@ -190,7 +184,6 @@ class BackingImage extends React.Component {
     const diskStateMapDetailModalProps = {
       selected,
       backingImages,
-      cleanUp,
       visible: diskStateMapDetailModalVisible,
       onCancel: () => {
         dispatch({ type: 'backingImage/hideDiskStateMapDetailModal' })

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -76,13 +76,13 @@ class BackingImage extends React.Component {
     if (field && (value || createdFromValue)) {
       switch (field) {
         case 'name':
-          backingImages = backingImages.filter((image) => image.name.includes(value.trim()))
+          backingImages = backingImages.filter((image) => (value ? image.name.includes(value.trim()) : true))
           break
         case 'uuid':
-          backingImages = backingImages.filter((image) => image.uuid.includes(value.trim()))
+          backingImages = backingImages.filter((image) => (value ? image.uuid.includes(value.trim()) : true))
           break
         case 'sourceType':
-          backingImages = backingImages.filter((image) => image.sourceType === createdFromValue.trim())
+          backingImages = backingImages.filter((image) => (createdFromValue ? image.sourceType === createdFromValue?.trim() : true))
           break
         default:
           break

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -264,6 +264,12 @@ class BackingImage extends React.Component {
           payload: record,
         })
       },
+      downloadSelectedBackingImages(record) {
+        dispatch({
+          type: 'backingImage/bulkDownload',
+          payload: record,
+        })
+      },
     }
 
     let inUploadProgress = backingImageUploadStarted

--- a/src/routes/volume/index.js
+++ b/src/routes/volume/index.js
@@ -59,6 +59,7 @@ import {
 } from './helper'
 import { healthyVolume, inProgressVolume, degradedVolume, detachedVolume, faultedVolume, filterVolume, isVolumeImageUpgradable, isVolumeSchedule } from '../../utils/filter'
 import C from '../../utils/constants'
+import { hasReadyBackingDisk } from '../../utils/status'
 
 const confirm = Modal.confirm
 
@@ -761,7 +762,7 @@ class Volume extends React.Component {
       v1DataEngineEnabled,
       v2DataEngineEnabled,
       diskTags,
-      backingImages,
+      backingImages: backingImages?.filter(image => hasReadyBackingDisk(image)) || [],
       tagsLoading,
       hosts,
       visible: createVolumeModalVisible,

--- a/src/services/backingImage.js
+++ b/src/services/backingImage.js
@@ -28,9 +28,21 @@ export async function deleteBackingImage(params) {
   }
 }
 
+export async function bulkDownload(images) {
+  for (const image of images) {
+    if (image?.name) {
+      // eslint-disable-next-line no-underscore-dangle
+      const downloadUrl = `${window.__pathname_prefix__}${window.__pathname_prefix__.endsWith('/') ? '' : '/'}v1/backingimages/${image.name}/download`
+      // specific way to download multiple files with one click, User may allow the browser to download multiple files at once
+      Object.assign(document.createElement('a'), { href: downloadUrl, download: image.name }).click()
+    }
+  }
+}
+
 export async function download(params) {
   if (params && params.name) {
-    window.location.href = `${ window.__pathname_prefix__ }${ window.__pathname_prefix__.endsWith('/') ? '' : '/'}v1/backingimages/${params.name}/download` // eslint-disable-line
+    // eslint-disable-next-line no-underscore-dangle
+    window.location.href = `${window.__pathname_prefix__}${window.__pathname_prefix__.endsWith('/') ? '' : '/'}v1/backingimages/${params.name}/download`
   }
 }
 

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -70,7 +70,7 @@ export function schedulingDisabledNode(data) { return data.filter(node => isDisa
 // Node is not ready by condition.
 export function downNode(data) { return data.filter(node => isDown(node)) }
 
-function filterData(data, field, value) {
+export function filterData(data, field, value) {
   return data.filter(item => (item[field] || '').toLowerCase().indexOf(value.toLowerCase()) > -1)
 }
 

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -29,9 +29,12 @@ const isDown = (node) => node.conditions && node.conditions.Ready && node.condit
 
 export const diskStatusColorMap = {
   ready: { color: '#27AE5F', bg: 'rgba(39,174,95,.05)' }, // green
+  starting: { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
+  pending: { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
   'in-progress': { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
   'ready-for-transfer': { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
   'failed-and-cleanup': { color: '#F15354', bg: 'rgba(241,83,84,.05)' }, // red
+  failed: { color: '#F15354', bg: 'rgba(241,83,84,.05)' }, // red
 }
 
 export const nodeStatusColorMap = {

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -35,13 +35,13 @@ export const diskStatusColorMap = {
 }
 
 export const nodeStatusColorMap = {
-  schedulable: { color: '#27AE5F', bg: 'rgba(39,174,95,.05)' },
-  unschedulable: { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' },
+  schedulable: { color: '#27AE5F', bg: 'rgba(39,174,95,.05)' }, // green
+  unschedulable: { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
   // autoEvicting nodes are a subset of unschedulable nodes. We use the same color to represent both.
-  autoEvicting: { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' },
-  down: { color: '#F15354', bg: 'rgba(241,83,84,.1)' },
-  disabled: { color: '#dee1e3', bg: 'rgba(222,225,227,.05)' },
-  unknown: { color: '#F15354', bg: 'rgba(241,83,84,.05)' },
+  autoEvicting: { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
+  down: { color: '#F15354', bg: 'rgba(241,83,84,.1)' }, // red
+  disabled: { color: '#dee1e3', bg: 'rgba(222,225,227,.05)' }, // grey
+  unknown: { color: '#F15354', bg: 'rgba(241,83,84,.05)' }, // red
 }
 export function getNodeStatus(node) {
   // autoEvicting nodes are a subset of unschedulable nodes and the autoEvicting status takes precedence for display.
@@ -70,7 +70,7 @@ export function schedulingDisabledNode(data) { return data.filter(node => isDisa
 // Node is not ready by condition.
 export function downNode(data) { return data.filter(node => isDown(node)) }
 
-export function filterData(data, field, value) {
+function filterData(data, field, value) {
   return data.filter(item => (item[field] || '').toLowerCase().indexOf(value.toLowerCase()) > -1)
 }
 

--- a/src/utils/filter.js
+++ b/src/utils/filter.js
@@ -26,6 +26,14 @@ const isAutoEvicting = (node) => node.conditions && node.conditions.Ready && nod
 const isDisabled = (node) => node.conditions && node.conditions.Ready && node.conditions.Ready.status.toLowerCase() === 'true'
                                              && (node.allowScheduling === false || Object.values(node.disks).every(d => d.allowScheduling === false))
 const isDown = (node) => node.conditions && node.conditions.Ready && node.conditions.Ready.status.toLowerCase() === 'false'
+
+export const diskStatusColorMap = {
+  ready: { color: '#27AE5F', bg: 'rgba(39,174,95,.05)' }, // green
+  'in-progress': { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
+  'ready-for-transfer': { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' }, // yellow
+  'failed-and-cleanup': { color: '#F15354', bg: 'rgba(241,83,84,.05)' }, // red
+}
+
 export const nodeStatusColorMap = {
   schedulable: { color: '#27AE5F', bg: 'rgba(39,174,95,.05)' },
   unschedulable: { color: '#F1C40F', bg: 'rgba(241,196,15,.05)' },


### PR DESCRIPTION
### What this PR does / why we need it
PRs for [[IMPROVEMENT] BackingImage UI improvement](https://github.com/longhorn/longhorn/issues/7293) are implemented in 
- https://github.com/longhorn/longhorn-ui/pull/728
- https://github.com/longhorn/longhorn-ui/pull/729
- https://github.com/longhorn/longhorn-ui/pull/736
- https://github.com/longhorn/longhorn-ui/pull/738

Cherry pick the commits to `v1.6.x` branch.

### Issue
[[BACKPORT][v1.6.3][IMPROVEMENT] BackingImage UI improvement](https://github.com/longhorn/longhorn/issues/8655)

### Test Result
Test locally
* Acking Image should show the source of it.
    * For export-from-volume: volume-name  ✅ 
    * For download: url  ✅ 
    * For upload: `` (empty)  ✅ 
*  Add filter so user can filter the BackingImage with other properties (e.g. Created From)  ✅ 
*  Bulk download BackingImages  ✅ 
*  BackingImages can show different colors for backing image status  ✅ 
*  Remove cleanup operation, instead, move the cleanup function in detail page  ✅ 
*  Filter out non-ready status backing image in volume create modal dropdown.  ✅ 
*  Change clean up modal wording and style ✅ 

### Additional documentation or context
N/A