### PR TITLE
Add backup backing image table

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,6 @@
     "linebreak-style": [0 ,"error", "windows"],
     "react/no-access-state-in-setstate": 0,
     "react/jsx-first-prop-new-line": 0,
-    "react/jsx-props-no-spreading": 0,
     "import/prefer-default-export": 0,
     "react/jsx-filename-extension": 0,
     "react/jsx-props-no-spreading": 0,

--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
     "linebreak-style": [0 ,"error", "windows"],
     "react/no-access-state-in-setstate": 0,
     "react/jsx-first-prop-new-line": 0,
+    "react/jsx-props-no-spreading": 0,
     "import/prefer-default-export": 0,
     "react/jsx-filename-extension": 0,
     "react/jsx-props-no-spreading": 0,

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -22,6 +22,8 @@
     "unit-no-unknown": null,
     "no-descending-specificity": null,
     "value-list-max-empty-lines": null,
-    "selector-type-no-unknown": null
+    "selector-type-no-unknown": null,
+    "selector-class-pattern": null,
+    "selector-id-pattern": null
   }
 }

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -9,7 +9,7 @@ const Option = Select.Option
 class Filter extends React.Component {
   constructor(props) {
     super(props)
-    const { field = props.defaultField || 'name', value = '', stateValue = '', nodeRedundancyValue = '', engineImageUpgradableValue = '', scheduleValue = '', pvStatusValue = '', revisionCounterValue = '', isGroupValue = '', createdFromValue = '' } = queryString.parse(props.location.search)
+    const { field = props.defaultField || 'name', value = '', stateValue = '', nodeRedundancyValue = '', engineImageUpgradableValue = '', scheduleValue = '', pvStatusValue = '', revisionCounterValue = '', isGroupValue = '' } = queryString.parse(props.location.search)
     this.state = {
       field,
       stateValue,
@@ -19,7 +19,6 @@ class Filter extends React.Component {
       scheduleValue,
       pvStatusValue,
       revisionCounterValue,
-      createdFromValue,
       isGroupValue,
       keyword: value,
     }
@@ -65,7 +64,7 @@ class Filter extends React.Component {
   }
 
   handleCreatedFromValueChange = (createdFromValue) => {
-    this.setState({ ...this.state, createdFromValue })
+    this.setState({ ...this.state, value: createdFromValue })
   }
 
   handleFieldChange = (field) => {
@@ -73,7 +72,7 @@ class Filter extends React.Component {
   }
 
   render() {
-    const { field = this.props.defaultField || 'name', value = '', stateValue = '', nodeRedundancyValue = '', engineImageUpgradableValue = '', scheduleValue = '', pvStatusValue = '', revisionCounterValue = '', isGroup = '', createdFromValue = '' } = queryString.parse(this.props.location.search)
+    const { field = this.props.defaultField || 'name', value = '', stateValue = '', nodeRedundancyValue = '', engineImageUpgradableValue = '', scheduleValue = '', pvStatusValue = '', revisionCounterValue = '', isGroup = '' } = queryString.parse(this.props.location.search)
 
     let defaultContent = {
       field,
@@ -84,7 +83,6 @@ class Filter extends React.Component {
       scheduleValue,
       pvStatusValue,
       revisionCounterValue,
-      createdFromValue,
       isGroup,
     }
 
@@ -164,7 +162,7 @@ class Filter extends React.Component {
         style={{ width: '100%' }}
         size="large"
         allowClear
-        defaultValue={this.state.createdFromValue}
+        defaultValue={this.props.createdFromOption[0]?.value || ''}
         onChange={this.handleCreatedFromValueChange}
     >
     {this.props.createdFromOption.map(item => (<Option key={item.value} value={item.value}>{item.name}</Option>))}

--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -4,7 +4,7 @@ import { connect } from 'dva'
 import { Row, Col, Tooltip } from 'antd'
 import styles from './Footer.less'
 import { config } from '../../utils'
-import { getStatusIcon, getBackupStatusIcon, getSystemBackupStatusIcon } from '../../utils/websocket'
+import { getStatusIcon } from '../../utils/websocket'
 import upgradeIcon from '../../assets/images/upgrade.svg'
 import semver from 'semver'
 import BundlesModel from './BundlesModel'
@@ -126,12 +126,13 @@ function Footer({ app, host, volume, setting, engineimage, eventlog, backingImag
           {getStatusIcon(setting)}
           {getStatusIcon(engineimage)}
           {getStatusIcon(eventlog)}
-          {getStatusIcon(backingImage)}
+          {getStatusIcon(backingImage, 'backingImages')}
+          {getStatusIcon(backingImage, 'backupBackingImages')}
           {getStatusIcon(recurringJob)}
-          {getBackupStatusIcon(backup, 'backupVolumes')}
-          {getBackupStatusIcon(backup, 'backups')}
-          {getSystemBackupStatusIcon(systemBackups, 'systemBackup')}
-          {getSystemBackupStatusIcon(systemBackups, 'systemRestore')}
+          {getStatusIcon(backup, 'backupVolumes')}
+          {getStatusIcon(backup, 'backups')}
+          {getStatusIcon(systemBackups, 'systemBackup')}
+          {getStatusIcon(systemBackups, 'systemRestore')}
         </Col>
         <BundlesModel key={bundlesropsKey} {...createBundlesrops} />
         <StableLonghornVersions key={stableLonghornVersionsKey} {...stableLonghornVersionsProps} />

--- a/src/models/backingImage.js
+++ b/src/models/backingImage.js
@@ -41,6 +41,10 @@ export default {
     diskStateMapDeleteLoading: false,
     selectedDiskStateMapRows: [],
     selectedDiskStateMapRowKeys: [],
+    biSearchField: '',
+    biSearchValue: '',
+    bbiSearchField: '',
+    bbiSearchValue: '',
     socketStatus: 'closed',
   },
   subscriptions: {
@@ -148,8 +152,11 @@ export default {
     *restoreBackingImage({
       payload,
     }, { call, put }) {
-      yield call(execAction, payload.actions.backupBackingImageRestore)
+      const resp = yield call(execAction, payload.actions.backupBackingImageRestore)
       yield delay(1000)
+      if (resp && resp.status === 200) {
+        message.success(`Successfully restore ${payload.name} backing image`)
+      }
       yield put({ type: 'query' })
     },
     *deleteBackupBackingImage({
@@ -274,6 +281,12 @@ export default {
   },
   reducers: {
     queryBackingImage(state, action) {
+      return {
+        ...state,
+        ...action.payload,
+      }
+    },
+    setSearchFilter(state, action) {
       return {
         ...state,
         ...action.payload,

--- a/src/models/backup.js
+++ b/src/models/backup.js
@@ -100,10 +100,10 @@ export default {
     *queryBackupTarget({
       payload,
     }, { call, put }) {
-      let resp = yield call(queryTarget)
+      const resp = yield call(queryTarget)
       if (resp && resp.data && resp.data[0]) {
         let isbackupVolumePage = true
-        let path = ['/node', '/dashboard', '/volume', '/engineimage', '/setting', '/backingImage', '/recurringJob']
+        let path = ['/node', '/dashboard', '/volume', '/engineimage', '/setting', '/recurringJob']
 
         isbackupVolumePage = payload.history && payload.history.location && payload.history.location.pathname && payload.history.location.pathname !== '/' && path.every(ele => !payload.history.location.pathname.startsWith(ele))
         if (isbackupVolumePage) {

--- a/src/models/systemBackups.js
+++ b/src/models/systemBackups.js
@@ -194,7 +194,7 @@ export default {
         systemRestoresValue: '',
       }
     },
-    updateSocketStatusSysteBackups(state, action) {
+    updateSocketStatusSystemBackups(state, action) {
       return { ...state, socketSystemBackupsStatus: action.payload }
     },
     updateSocketStatusSystemRestores(state, action) {

--- a/src/routes/backingImage/BackingImage.less
+++ b/src/routes/backingImage/BackingImage.less
@@ -47,3 +47,54 @@
     height: 50;
     z-index: 9999;
 }
+.backupBackingImageTitle {
+  background: #ecf0f1 !important;
+  display: flex;
+  align-items: center;
+  height: 50px;
+  font-size: 20px;
+}
+
+:global {
+  #backingImageTable{
+    .ant-table {
+      height: calc(100% - 64px);
+      margin-bottom: 16px;
+      overflow: hidden;
+      .ant-table-body{
+        height: 100%;
+        overflow: auto;
+      }
+    }
+    .common-table-class {
+      height: 100%;
+      .ant-spin-nested-loading {
+        height: 100%;
+        .ant-spin-container{
+          height: 100%
+        }
+      }
+    }
+  }
+
+  #backupBackingImageTable {
+    .ant-table {
+      height: calc(100% - 64px);
+      margin-bottom: 16px;
+      overflow: hidden;
+      .ant-table-body{
+        height: 100%;
+        overflow: auto;
+      }
+    }
+    .common-table-class {
+      height: 100%;
+      .ant-spin-nested-loading {
+        height: 100%;
+        .ant-spin-container{
+          height: 100%
+        }
+      }
+    }
+  }
+}

--- a/src/routes/backingImage/BackingImage.less
+++ b/src/routes/backingImage/BackingImage.less
@@ -47,6 +47,7 @@
     height: 50;
     z-index: 9999;
 }
+
 .backupBackingImageTitle {
   background: #ecf0f1 !important;
   display: flex;
@@ -61,10 +62,6 @@
       height: calc(100% - 64px);
       margin-bottom: 16px;
       overflow: hidden;
-      .ant-table-body{
-        height: 100%;
-        overflow: auto;
-      }
     }
     .common-table-class {
       height: 100%;
@@ -82,10 +79,6 @@
       height: calc(100% - 64px);
       margin-bottom: 16px;
       overflow: hidden;
-      .ant-table-body{
-        height: 100%;
-        overflow: auto;
-      }
     }
     .common-table-class {
       height: 100%;

--- a/src/routes/backingImage/BackingImageActions.js
+++ b/src/routes/backingImage/BackingImageActions.js
@@ -5,15 +5,15 @@ import { DropOption } from '../../components'
 import { hasReadyBackingDisk } from '../../utils/status'
 const confirm = Modal.confirm
 
-function actions({ selected, deleteBackingImage, downloadBackingImage, showUpdateMinCopiesCount }) {
+function actions({ selected, deleteBackingImage, downloadBackingImage, showUpdateMinCopiesCount, createBackupBackingImage }) {
   const handleMenuClick = (event, record) => {
     event.domEvent?.stopPropagation?.()
     switch (event.key) {
       case 'delete':
         confirm({
-          title: `Are you sure you want to delete backing image ${record.name}?`,
-          okType: 'danger',
           okText: 'Delete',
+          okType: 'danger',
+          title: `Are you sure you want to delete ${record.name} backing image ?`,
           onOk() {
             deleteBackingImage(record)
           },
@@ -22,6 +22,9 @@ function actions({ selected, deleteBackingImage, downloadBackingImage, showUpdat
       case 'download':
         downloadBackingImage(record)
         break
+      case 'backup':
+        createBackupBackingImage(record)
+        break
       case 'updateMinCopies':
         showUpdateMinCopiesCount(record)
         break
@@ -29,11 +32,12 @@ function actions({ selected, deleteBackingImage, downloadBackingImage, showUpdat
     }
   }
 
-  const disableDownloadAction = !hasReadyBackingDisk(selected)
+  const disableAction = !hasReadyBackingDisk(selected)
 
   const availableActions = [
-    { key: 'updateMinCopies', name: 'Update Minimum Copies Count', disabled: disableDownloadAction, tooltip: disableDownloadAction ? 'Missing disk with ready state' : '' },
-    { key: 'download', name: 'Download', disabled: disableDownloadAction, tooltip: disableDownloadAction ? 'Missing disk with ready state' : '' },
+    { key: 'updateMinCopies', name: 'Update Minimum Copies Count', disabled: disableAction, tooltip: disableAction ? 'Missing disk with ready state' : '' },
+    { key: 'backup', name: ' Backup', disabled: disableAction, tooltip: disableAction ? 'Missing disk with ready state' : '' },
+    { key: 'download', name: 'Download', disabled: disableAction, tooltip: disableAction ? 'Missing disk with ready state' : '' },
     { key: 'delete', name: 'Delete' },
   ]
 
@@ -49,6 +53,7 @@ actions.propTypes = {
   deleteBackingImage: PropTypes.func,
   downloadBackingImage: PropTypes.func,
   showUpdateMinCopiesCount: PropTypes.func,
+  createBackupBackingImage: PropTypes.func,
 }
 
 export default actions

--- a/src/routes/backingImage/BackingImageBulkActions.js
+++ b/src/routes/backingImage/BackingImageBulkActions.js
@@ -13,8 +13,8 @@ function bulkActions({ selectedRows, deleteBackingImages, downloadSelectedBackin
       case 'delete':
         confirm({
           width: 'fit-content',
-          okType: 'danger',
           okText: 'Delete',
+          okType: 'danger',
           title: (<>
                     <p>Are you sure to delete below {count} backing {count === 1 ? 'image' : 'images' } ?</p>
                     <ul>

--- a/src/routes/backingImage/BackingImageBulkActions.js
+++ b/src/routes/backingImage/BackingImageBulkActions.js
@@ -90,7 +90,7 @@ function bulkActions({ selectedRows, deleteBackingImages, downloadSelectedBackin
   const allActions = [
     { key: 'delete', name: 'Delete', disabled() { return selectedRows.length === 0 } },
     { key: 'download', name: 'Download', disabled() { return (selectedRows.length === 0 || selectedRows.every(row => !hasReadyBackingDisk(row))) } },
-    { key: 'backup', name: 'Backup', disabled() { return selectedRows.length === 0 } },
+    { key: 'backup', name: 'Backup', disabled() { return selectedRows.length === 0 || selectedRows.every(row => !hasReadyBackingDisk(row)) } },
   ]
 
   return (

--- a/src/routes/backingImage/BackingImageBulkActions.js
+++ b/src/routes/backingImage/BackingImageBulkActions.js
@@ -6,7 +6,7 @@ import { hasReadyBackingDisk, diskStatusColorMap } from '../../utils/status'
 const confirm = Modal.confirm
 
 
-function bulkActions({ selectedRows, deleteBackingImages, downloadSelectedBackingImages }) {
+function bulkActions({ selectedRows, deleteBackingImages, downloadSelectedBackingImages, backupSelectedBackingImages }) {
   const handleClick = (action) => {
     const count = selectedRows.length
     switch (action) {
@@ -55,14 +55,42 @@ function bulkActions({ selectedRows, deleteBackingImages, downloadSelectedBackin
         })
         break
       }
+      case 'backup': {
+        const backupImages = selectedRows.filter(row => hasReadyBackingDisk(row))
+        const readyColor = diskStatusColorMap.ready
+        const readyTextStyle = {
+          display: 'inline-block',
+          width: 'max-content',
+          padding: '0 4px',
+          marginRight: '5px',
+          color: '#27AE5F',
+          border: `1px solid ${readyColor.color}`,
+          backgroundColor: readyColor.bg,
+          textTransform: 'capitalize',
+        }
+        confirm({
+          okText: 'Backup',
+          width: 'fit-content',
+          title: (<>
+                    <p>Are you sure to backup below <strong style={readyTextStyle}>Ready</strong> status backing {count === 1 ? 'image' : 'images'} ?</p>
+                    <ul>
+                      {backupImages.map(item => <li key={item.name}>{item.name}</li>)}
+                    </ul>
+                  </>),
+          onOk() {
+            backupSelectedBackingImages(backupImages)
+          },
+        })
+        break
+      }
       default:
-        // show nothing
     }
   }
 
   const allActions = [
     { key: 'delete', name: 'Delete', disabled() { return selectedRows.length === 0 } },
     { key: 'download', name: 'Download', disabled() { return (selectedRows.length === 0 || selectedRows.every(row => !hasReadyBackingDisk(row))) } },
+    { key: 'backup', name: 'Backup', disabled() { return selectedRows.length === 0 } },
   ]
 
   return (
@@ -81,6 +109,8 @@ function bulkActions({ selectedRows, deleteBackingImages, downloadSelectedBackin
 bulkActions.propTypes = {
   selectedRows: PropTypes.array,
   deleteBackingImages: PropTypes.func,
+  downloadSelectedBackingImages: PropTypes.func,
+  backupSelectedBackingImages: PropTypes.func,
 }
 
 export default bulkActions

--- a/src/routes/backingImage/BackingImageList.js
+++ b/src/routes/backingImage/BackingImageList.js
@@ -166,20 +166,18 @@ function list({ loading, dataSource, deleteBackingImage, showDiskStateMapDetail,
   ]
 
   return (
-    <div id="backingImageTable" style={{ flex: 1, height: '1px', overflow: 'hidden' }}>
-      <Table
-        className="common-table-class"
-        bordered={false}
-        columns={columns}
-        rowSelection={rowSelection}
-        dataSource={dataSource}
-        loading={loading}
-        simple
-        pagination={pagination}
-        rowKey={record => record.id}
-        scroll={{ x: 970, y: dataSource.length > 0 ? height : 1 }}
-      />
-    </div>
+    <Table
+      className="common-table-class"
+      bordered={false}
+      columns={columns}
+      rowSelection={rowSelection}
+      dataSource={dataSource}
+      loading={loading}
+      simple
+      pagination={pagination('backingImage')}
+      rowKey={record => record.id}
+      scroll={{ x: 970, y: dataSource.length > 0 ? height : 1 }}
+    />
   )
 }
 

--- a/src/routes/backingImage/BackingImageList.js
+++ b/src/routes/backingImage/BackingImageList.js
@@ -6,10 +6,11 @@ import { pagination } from '../../utils/page'
 import { formatMib } from '../../utils/formatter'
 import { nodeTagColor, diskTagColor } from '../../utils/constants'
 
-function list({ loading, dataSource, deleteBackingImage, showDiskStateMapDetail, rowSelection, downloadBackingImage, showUpdateMinCopiesCount, height }) {
+function list({ loading, dataSource, deleteBackingImage, showDiskStateMapDetail, rowSelection, createBackupBackingImage, downloadBackingImage, showUpdateMinCopiesCount, height }) {
   const backingImageActionsProps = {
     deleteBackingImage,
     downloadBackingImage,
+    createBackupBackingImage,
     showUpdateMinCopiesCount,
   }
 
@@ -184,6 +185,7 @@ function list({ loading, dataSource, deleteBackingImage, showDiskStateMapDetail,
 list.propTypes = {
   loading: PropTypes.bool,
   dataSource: PropTypes.array,
+  createBackupBackingImage: PropTypes.func,
   deleteBackingImage: PropTypes.func,
   showDiskStateMapDetail: PropTypes.func,
   showUpdateMinCopiesCount: PropTypes.func,

--- a/src/routes/backingImage/BackupBackingImageActions.js
+++ b/src/routes/backingImage/BackupBackingImageActions.js
@@ -1,0 +1,49 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Modal } from 'antd'
+import { DropOption } from '../../components'
+// import { hasReadyBackingDisk } from '../../utils/status'
+const confirm = Modal.confirm
+
+function actions({ selected, deleteBackupBackingImage, restoreBackingImage }) {
+  const handleMenuClick = (event, record) => {
+    event.domEvent?.stopPropagation?.()
+    switch (event.key) {
+      case 'delete':
+        confirm({
+          okText: 'Delete',
+          okType: 'danger',
+          title: <p>Are you sure you want to delete <strong>{record.name}</strong> backing image backup ?</p>,
+          onOk() {
+            deleteBackupBackingImage(record)
+          },
+        })
+        break
+      case 'restore':
+        restoreBackingImage(record)
+        break
+      default:
+    }
+  }
+
+  const disableRestoreAction = selected.state !== 'Completed'
+
+  const availableActions = [
+    { key: 'restore', name: 'Restore', disabled: disableRestoreAction, tooltip: disableRestoreAction ? 'Only complete state backup can be restored' : '' },
+    { key: 'delete', name: 'Delete' },
+  ]
+
+  return (
+    <DropOption menuOptions={availableActions}
+      onMenuClick={(e) => handleMenuClick(e, selected)}
+    />
+  )
+}
+
+actions.propTypes = {
+  selected: PropTypes.object,
+  deleteBackupBackingImage: PropTypes.func,
+  restoreBackingImage: PropTypes.func,
+}
+
+export default actions

--- a/src/routes/backingImage/BackupBackingImageActions.js
+++ b/src/routes/backingImage/BackupBackingImageActions.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Modal } from 'antd'
 import { DropOption } from '../../components'
-// import { hasReadyBackingDisk } from '../../utils/status'
 const confirm = Modal.confirm
 
 function actions({ selected, deleteBackupBackingImage, restoreBackingImage }) {

--- a/src/routes/backingImage/BackupBackingImageBulkActions.js
+++ b/src/routes/backingImage/BackupBackingImageBulkActions.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button, Modal } from 'antd'
+// import { hasReadyBackingDisk } from '../../utils/status'
+// import { diskStatusColorMap } from '../../utils/filter'
+
+const confirm = Modal.confirm
+
+
+function bulkActions({ bbiSelectedRows, deleteBackupBackingImages }) {
+  const handleClick = (action) => {
+    const count = bbiSelectedRows.length
+    switch (action) {
+      case 'delete':
+        confirm({
+          width: 'fit-content',
+          okText: 'Delete',
+          okType: 'danger',
+          title: (<>
+                    <p>Are you sure to delete below {count} backup backing {count === 1 ? 'image' : 'images' } ?</p>
+                    <ul>
+                      {bbiSelectedRows.map(item => <li>{item.name}</li>)},
+                    </ul>
+                  </>),
+          onOk() {
+            deleteBackupBackingImages(bbiSelectedRows)
+          },
+        })
+        break
+      default:
+    }
+  }
+
+  const allActions = [
+    { key: 'delete', name: 'Delete', disabled() { return bbiSelectedRows.length === 0 } },
+  ]
+
+  return (
+    <div style={{ display: 'flex' }}>
+      { allActions.map(item => {
+        return (
+          <div key={item.key} style={{ marginRight: '10px' }}>
+            <Button size="large" type="primary" disabled={item.disabled()} onClick={() => handleClick(item.key)}>{ item.name }</Button>
+          </div>
+        )
+      }) }
+    </div>
+  )
+}
+
+bulkActions.propTypes = {
+  bbiSelectedRows: PropTypes.array,
+  deleteBackupBackingImages: PropTypes.func,
+}
+
+export default bulkActions

--- a/src/routes/backingImage/BackupBackingImageBulkActions.js
+++ b/src/routes/backingImage/BackupBackingImageBulkActions.js
@@ -1,8 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Button, Modal } from 'antd'
-// import { hasReadyBackingDisk } from '../../utils/status'
-// import { diskStatusColorMap } from '../../utils/filter'
 
 const confirm = Modal.confirm
 

--- a/src/routes/backingImage/BackupBackingImageBulkActions.js
+++ b/src/routes/backingImage/BackupBackingImageBulkActions.js
@@ -4,7 +4,6 @@ import { Button, Modal } from 'antd'
 
 const confirm = Modal.confirm
 
-
 function bulkActions({ bbiSelectedRows, deleteBackupBackingImages }) {
   const handleClick = (action) => {
     const count = bbiSelectedRows.length

--- a/src/routes/backingImage/BackupBackingImageList.js
+++ b/src/routes/backingImage/BackupBackingImageList.js
@@ -1,0 +1,100 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Table } from 'antd'
+import BackupBackingImageActions from './BackupBackingImageActions'
+import { pagination } from '../../utils/page'
+import { formatMib } from '../../utils/formatter'
+import { formatDate } from '../../utils/formatDate'
+
+function list({ loading, dataSource, deleteBackupBackingImage, restoreBackingImage, rowSelection, height }) {
+  // console.log('🚀 ~ list ~ dataSource:', dataSource)
+  const actionsProps = {
+    deleteBackupBackingImage,
+    restoreBackingImage,
+  }
+
+  const columns = [
+    {
+      title: 'Name',
+      dataIndex: 'name',
+      key: 'name',
+      width: 200,
+      sorter: (a, b) => a.name.localeCompare(b.name),
+      render: (text) => {
+        return (<div>{text}</div>)
+      },
+    }, {
+      title: 'State',
+      dataIndex: 'state',
+      key: 'state',
+      width: 150,
+      sorter: (a, b) => a.state.localeCompare(b.state),
+      render: (text) => {
+        return (
+          <div>{text}</div>
+        )
+      },
+    }, {
+      title: 'Size',
+      dataIndex: 'size',
+      key: 'size',
+      width: 150,
+      sorter: (a, b) => parseInt(a.size, 10) - parseInt(b.size, 10),
+      render: (text) => {
+        return (
+          <div>
+            {formatMib(text)}
+          </div>
+        )
+      },
+    }, {
+      title: 'Created From',
+      dataIndex: 'created',
+      key: 'created',
+      width: 200,
+      sorter: (a, b) => a.created.localeCompare(b.created),
+      render: (text) => {
+        return (
+          <div>
+            {text ? formatDate(text) : ''}
+          </div>
+        )
+      },
+    }, {
+      title: 'Operation',
+      key: 'operation',
+      width: 120,
+      render: (_text, record) => {
+        return (
+          <BackupBackingImageActions {...actionsProps} selected={record} />
+        )
+      },
+    },
+  ]
+
+  return (
+    <Table
+      className="common-table-class"
+      bordered={false}
+      columns={columns}
+      rowSelection={rowSelection}
+      dataSource={dataSource}
+      loading={loading}
+      simple
+      pagination={pagination('backupBackingImage')}
+      rowKey={record => record.id}
+      scroll={{ x: 970, y: dataSource.length > 0 ? height : 1 }}
+    />
+  )
+}
+
+list.propTypes = {
+  loading: PropTypes.bool,
+  dataSource: PropTypes.array,
+  deleteBackupBackingImage: PropTypes.func,
+  restoreBackingImage: PropTypes.func,
+  rowSelection: PropTypes.object,
+  height: PropTypes.number,
+}
+
+export default list

--- a/src/routes/backingImage/BackupBackingImageList.js
+++ b/src/routes/backingImage/BackupBackingImageList.js
@@ -7,7 +7,6 @@ import { formatMib } from '../../utils/formatter'
 import { formatDate } from '../../utils/formatDate'
 
 function list({ loading, dataSource, deleteBackupBackingImage, restoreBackingImage, rowSelection, height }) {
-  // console.log('🚀 ~ list ~ dataSource:', dataSource)
   const actionsProps = {
     deleteBackupBackingImage,
     restoreBackingImage,
@@ -18,7 +17,7 @@ function list({ loading, dataSource, deleteBackupBackingImage, restoreBackingIma
       title: 'Name',
       dataIndex: 'name',
       key: 'name',
-      width: 200,
+      width: 120,
       sorter: (a, b) => a.name.localeCompare(b.name),
       render: (text) => {
         return (<div>{text}</div>)
@@ -27,7 +26,7 @@ function list({ loading, dataSource, deleteBackupBackingImage, restoreBackingIma
       title: 'State',
       dataIndex: 'state',
       key: 'state',
-      width: 150,
+      width: 80,
       sorter: (a, b) => a.state.localeCompare(b.state),
       render: (text) => {
         return (
@@ -38,7 +37,7 @@ function list({ loading, dataSource, deleteBackupBackingImage, restoreBackingIma
       title: 'Size',
       dataIndex: 'size',
       key: 'size',
-      width: 150,
+      width: 80,
       sorter: (a, b) => parseInt(a.size, 10) - parseInt(b.size, 10),
       render: (text) => {
         return (
@@ -48,10 +47,24 @@ function list({ loading, dataSource, deleteBackupBackingImage, restoreBackingIma
         )
       },
     }, {
-      title: 'Created From',
+      title: 'URL',
+      dataIndex: 'url',
+      key: 'url',
+      width: 200,
+      sorter: (a, b) => a.url.localeCompare(b.url),
+      render: (text) => {
+        return (
+          <div>
+            {text}
+          </div>
+        )
+      },
+    },
+    {
+      title: 'Created Time',
       dataIndex: 'created',
       key: 'created',
-      width: 200,
+      width: 100,
       sorter: (a, b) => a.created.localeCompare(b.created),
       render: (text) => {
         return (

--- a/src/routes/backingImage/BackupBackingImageList.js
+++ b/src/routes/backingImage/BackupBackingImageList.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Table } from 'antd'
+import { Table, message } from 'antd'
+import { CopyToClipboard } from 'react-copy-to-clipboard'
 import BackupBackingImageActions from './BackupBackingImageActions'
 import { pagination } from '../../utils/page'
 import { formatMib } from '../../utils/formatter'
@@ -10,6 +11,14 @@ function list({ loading, dataSource, deleteBackupBackingImage, restoreBackingIma
   const actionsProps = {
     deleteBackupBackingImage,
     restoreBackingImage,
+  }
+
+  const onCopy = (_text, copySuccess) => {
+    if (copySuccess) {
+      message.success('Copied', 1.5)
+    } else {
+      message.error('Copy failed', 1.5)
+    }
   }
 
   const columns = [
@@ -50,12 +59,14 @@ function list({ loading, dataSource, deleteBackupBackingImage, restoreBackingIma
       title: 'URL',
       dataIndex: 'url',
       key: 'url',
-      width: 200,
+      width: 240,
       sorter: (a, b) => a.url.localeCompare(b.url),
       render: (text) => {
         return (
           <div>
-            {text}
+            <CopyToClipboard onCopy={onCopy} text={text}>
+              <p style={{ color: '#108ee9', cursor: 'pointer', margin: 'auto' }}>{text}</p>
+            </CopyToClipboard>
           </div>
         )
       },
@@ -64,7 +75,7 @@ function list({ loading, dataSource, deleteBackupBackingImage, restoreBackingIma
       title: 'Created Time',
       dataIndex: 'created',
       key: 'created',
-      width: 100,
+      width: 80,
       sorter: (a, b) => a.created.localeCompare(b.created),
       render: (text) => {
         return (

--- a/src/routes/backingImage/DiskStateMapDetail.js
+++ b/src/routes/backingImage/DiskStateMapDetail.js
@@ -161,6 +161,7 @@ const modal = ({
                 {currentData.sourceType === 'upload' && 'Upload'}
                 {currentData.sourceType === 'export-from-volume' && 'Export from a Longhorn volume'}
                 {currentData.sourceType === 'clone' && 'Clone from existing backing image'}
+                {currentData.sourceType === 'restore' && 'Restore from backup backing image'}
               </span>
               <div style={{ textAlign: 'left' }}>Parameters During Creation</div>
               <div>

--- a/src/routes/backingImage/RestoreBackupBackingImageModal.js
+++ b/src/routes/backingImage/RestoreBackupBackingImageModal.js
@@ -1,0 +1,76 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Form, Input } from 'antd'
+import { ModalBlur } from '../../components'
+
+const FormItem = Form.Item
+
+const formItemLayout = {
+  labelCol: {
+    span: 10,
+  },
+  wrapperCol: {
+    span: 12,
+  },
+}
+
+const modal = ({
+  item,
+  visible,
+  onOk,
+  onCancel,
+  form: {
+    getFieldDecorator,
+    validateFields,
+    getFieldValue,
+  },
+}) => {
+  function handleOk() {
+    validateFields((errors) => {
+      if (errors) {
+        return
+      }
+      const data = {
+        secret: getFieldValue('secret') || '',
+        secretNamespace: getFieldValue('secretNamespace') || '',
+      }
+      onOk(item, data)
+    })
+  }
+
+  const modalOpts = {
+    title: `Restore ${item.name} Backup Backing Image`,
+    visible,
+    onCancel,
+    onOk: handleOk,
+  }
+  if (!item) {
+    return null
+  }
+  return (
+    <ModalBlur {...modalOpts}>
+      <Form layout="horizontal">
+         <FormItem label="Secret" hasFeedback {...formItemLayout}>
+              {getFieldDecorator('secret', {
+                initialValue: '',
+              })(<Input />)}
+            </FormItem>
+            <FormItem label="Secret Namespace" hasFeedback {...formItemLayout}>
+              {getFieldDecorator('secretNamespace', {
+                initialValue: '',
+              })(<Input />)}
+            </FormItem>
+      </Form>
+    </ModalBlur>
+  )
+}
+
+modal.propTypes = {
+  form: PropTypes.object.isRequired,
+  visible: PropTypes.bool,
+  onCancel: PropTypes.func,
+  item: PropTypes.object,
+  onOk: PropTypes.func,
+}
+
+export default Form.create()(modal)

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -10,6 +10,7 @@ import { Filter } from '../../components/index'
 import BackingImageBulkActions from './BackingImageBulkActions'
 import UpdateMinCopiesCount from './UpdateMinCopiesCount'
 import BackupBackingImageBulkActions from './BackupBackingImageBulkActions'
+import RestoreBackupBackingImageModal from './RestoreBackupBackingImageModal'
 import style from './BackingImage.less'
 
 const filterBackingImage = (data, field, value) => {
@@ -21,9 +22,11 @@ const filterBackingImage = (data, field, value) => {
     case 'name':
     case 'uuid':
     case 'minNumberOfCopies':
+      backingImages = backingImages.filter((image) => (value ? image[field].toString().includes(value.toString().trim()) : true))
+      break
     case 'diskSelector':
     case 'nodeSelector':
-      backingImages = backingImages.filter((image) => (value ? image[field].toString().includes(value.toString().trim()) : true))
+      backingImages = backingImages.filter((image) => (value ? image[field]?.toString().includes(value.trim()) || false : true))
       break
     case 'sourceType':
       backingImages = backingImages.filter((image) => (value ? image.sourceType === value.trim() : true))
@@ -132,10 +135,12 @@ class BackingImage extends React.Component {
       bbiSearchField,
       bbiSearchValue,
       selected,
+      bbiSelected,
       nodeTags,
       diskTags,
       tagsLoading,
       minCopiesCountModalVisible,
+      restoreBackupBackingImageModalVisible,
       createBackingImageModalVisible,
       createBackingImageModalKey,
       diskStateMapDetailModalVisible,
@@ -169,8 +174,10 @@ class BackingImage extends React.Component {
       },
       restoreBackingImage(record) {
         dispatch({
-          type: 'backingImage/restoreBackingImage',
-          payload: record,
+          type: 'backingImage/showRestoreBackingImage',
+          payload: {
+            bbiSelected: record,
+          },
         })
       },
       rowSelection: {
@@ -282,6 +289,25 @@ class BackingImage extends React.Component {
         dispatch({
           type: 'app/changeBlur',
           payload: false,
+        })
+      },
+    }
+
+    const restoreBBiModalProps = {
+      item: bbiSelected,
+      visible: restoreBackupBackingImageModalVisible,
+      onOk(item, params) {
+        dispatch({
+          type: 'backingImage/restoreBackingImage',
+          payload: {
+            item,
+            params,
+          },
+        })
+      },
+      onCancel() {
+        dispatch({
+          type: 'backingImage/hideRestoreBackingImageModal',
         })
       },
     }
@@ -475,6 +501,7 @@ class BackingImage extends React.Component {
             <span>Uploading</span>
           </div>
         )}
+        { restoreBackupBackingImageModalVisible && <RestoreBackupBackingImageModal {...restoreBBiModalProps} />}
         { minCopiesCountModalVisible && <UpdateMinCopiesCount {...minCopiesCountProps} />}
         { createBackingImageModalVisible ? <CreateBackingImage key={createBackingImageModalKey} {...createBackingImageModalProps} /> : ''}
         { diskStateMapDetailModalVisible ? <DiskStateMapDetail key={diskStateMapDetailModalKey} {...diskStateMapDetailModalProps} /> : ''}

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -456,7 +456,7 @@ class BackingImage extends React.Component {
           <Icon type="file-image" className="ant-breadcrumb anticon" style={{ display: 'flex', alignItems: 'center' }} />
           <span style={{ marginLeft: '4px' }}>Backup Backing Image</span>
         </div>
-        <div id="backupBackingImageTable" style={{ height: '50%', padding: '8px 12px 0px' }}>
+        <div id="backupBackingImageTable" style={{ height: '45%', padding: '8px 12px 0px' }}>
           <Row gutter={24} style={{ marginBottom: 8 }}>
             <Col lg={17} md={15} sm={24} xs={24}>
               <BackupBackingImageBulkActions {...backupBackingImageBulkActionsProps} />

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { routerRedux } from 'dva/router'
 import { connect } from 'dva'
-import { Row, Col, Button, Progress, notification } from 'antd'
+import { Row, Col, Button, Progress, notification, Icon } from 'antd'
 import CreateBackingImage from './CreateBackingImage'
 import BackingImageList from './BackingImageList'
 import DiskStateMapDetail from './DiskStateMapDetail'
@@ -335,27 +335,49 @@ class BackingImage extends React.Component {
     let inUploadProgress = backingImageUploadStarted
 
     return (
-      <div className="content-inner" style={{ display: 'flex', flexDirection: 'column', overflow: 'visible !important' }}>
-        <Row gutter={24} style={{ marginBottom: 8 }}>
-          <Col lg={{ span: 4 }} md={{ span: 6 }} sm={24} xs={24}>
-            <BackingImageBulkActions {...backingImageBulkActionsProps} />
-          </Col>
-          <Col lg={{ offset: 13, span: 7 }} md={{ offset: 8, span: 10 }} sm={24} xs={24}>
-            <Filter {...backingImageFilterProps} />
-          </Col>
-        </Row>
-        { inUploadProgress ? (
+      <div className="content-inner" style={{ display: 'flex', padding: 0, flexDirection: 'column', overflow: 'visible !important' }}>
+        <div id="backingImageTable" style={{ height: '50%', padding: '8px 12px 0px' }}>
+          <Row gutter={24} style={{ marginBottom: 8 }}>
+            <Col lg={17} md={15} sm={24} xs={24}>
+              <BackingImageBulkActions {...backingImageBulkActionsProps} />
+            </Col>
+            <Col lg={7} md={9} sm={24} xs={24}>
+              <Filter {...backingImageFilterProps} />
+            </Col>
+          </Row>
+          <Button className="out-container-button" size="large" type="primary" disabled={inUploadProgress || loading} onClick={addBackingImage}>
+            Create Backing Image
+          </Button>
+          <Row style={{ marginBottom: 8, height: 'calc(100% - 48px)' }}>
+            <BackingImageList {...backingImageListProps} />
+          </Row>
+        </div>
+        <div className={style.backupBackingImageTitle}>
+          <Icon type="file-image" className="ant-breadcrumb anticon" style={{ display: 'flex', alignItems: 'center' }} />
+          <span style={{ marginLeft: '4px' }}>Backup Backing Image</span>
+        </div>
+        <div id="backupBackingImageTable" style={{ height: '45%', padding: '8px 12px 0px' }}>
+          <Row gutter={24} style={{ marginBottom: 8 }}>
+            <Col lg={17} md={15} sm={24} xs={24}>
+              <BackingImageBulkActions {...backingImageBulkActionsProps} />
+            </Col>
+            <Col lg={7} md={9} sm={24} xs={24}>
+              <Filter {...backingImageFilterProps} />
+            </Col>
+          </Row>
+          <Button className="out-container-button" size="large" type="primary" disabled={inUploadProgress || loading} onClick={addBackingImage}>
+            Create Backing Image
+          </Button>
+          <Row style={{ marginBottom: 8, height: 'calc(100% - 48px)' }}>
+            <BackingImageList {...backingImageListProps} />
+          </Row>
+        </div>
+        {inUploadProgress && (
           <div className={style.backingImageUploadingContainer}>
-            <div>
-              <Progress percent={backingImageUploadPercent} />
-              <span>Uploading</span>
-            </div>
+            <Progress percent={backingImageUploadPercent} />
+            <span>Uploading</span>
           </div>
-        ) : ''}
-        <Button className="out-container-button" size="large" type="primary" disabled={inUploadProgress || loading} onClick={addBackingImage}>
-          Create Backing Image
-        </Button>
-        <BackingImageList {...backingImageListProps} />
+        )}
         { minCopiesCountModalVisible && <UpdateMinCopiesCount {...minCopiesCountProps} />}
         { createBackingImageModalVisible ? <CreateBackingImage key={createBackingImageModalKey} {...createBackingImageModalProps} /> : ''}
         { diskStateMapDetailModalVisible ? <DiskStateMapDetail key={diskStateMapDetailModalKey} {...diskStateMapDetailModalProps} /> : ''}

--- a/src/routes/systemBackups/index.js
+++ b/src/routes/systemBackups/index.js
@@ -238,7 +238,7 @@ class SystemBackups extends React.Component {
           <SystemBackupsList {...systemBackupsListProps} />
         </div>
         <div className={style.systemRestores}>
-          <Icon type="file-done" className="ant-breadcrumb anticon" style={{ display: 'flex', alignItems: 'center' }} />
+          <Icon type="file-done" />
           <span style={{ marginLeft: '4px' }}>System Restore</span>
         </div>
         <div id="systemRestoresTable" style={{ height: '43%', padding: '8px 12px 0px' }}>

--- a/src/routes/systemBackups/index.js
+++ b/src/routes/systemBackups/index.js
@@ -238,7 +238,7 @@ class SystemBackups extends React.Component {
           <SystemBackupsList {...systemBackupsListProps} />
         </div>
         <div className={style.systemRestores}>
-          <Icon type="file-done" />
+          <Icon type="file-done" className="ant-breadcrumb anticon" style={{ display: 'flex', alignItems: 'center' }} />
           <span style={{ marginLeft: '4px' }}>System Restore</span>
         </div>
         <div id="systemRestoresTable" style={{ height: '43%', padding: '8px 12px 0px' }}>

--- a/src/routes/volume/CreateVolume.js
+++ b/src/routes/volume/CreateVolume.js
@@ -17,7 +17,7 @@ import { ModalBlur } from '../../components'
 import { frontends } from './helper/index'
 import { formatSize } from '../../utils/formatter'
 import { formatDate } from '../../utils/formatDate'
-import { sortSnapshots } from '../../utils/sort'
+import { sortByCreatedTime } from '../../utils/sort'
 
 const FormItem = Form.Item
 const { Panel } = Collapse
@@ -189,7 +189,7 @@ const modal = ({
   }
 
   const volumeSnapshots = snapshotsOptions?.length > 0 ? snapshotsOptions.filter(d => d.name !== 'volume-head') : []// no include volume-head
-  sortSnapshots(volumeSnapshots)
+  sortByCreatedTime(volumeSnapshots)
   const dataSourceAlertMsg = 'The volume size is set to the selected volume size. Mismatched size will cause create volume failed.'
   return (
     <ModalBlur {...modalOpts}>

--- a/src/services/backingImage.js
+++ b/src/services/backingImage.js
@@ -9,6 +9,21 @@ export async function query(params) {
   })
 }
 
+export async function execAction(url, params) {
+  return request({
+    url,
+    method: 'post',
+    data: params,
+  })
+}
+
+export async function queryBackupBackingImage() {
+  return request({
+    url: '/v1/backupbackingimages',
+    method: 'get',
+  })
+}
+
 export async function create(params) {
   return request({
     url: '/v1/backingimages',
@@ -19,11 +34,10 @@ export async function create(params) {
   })
 }
 
-export async function execAction(url, params) {
+export async function deleteBackupBackingImage(params) {
   return request({
-    url,
-    method: 'post',
-    data: params,
+    url: `/v1/backupbackingimages/${params.name}`,
+    method: 'delete',
   })
 }
 

--- a/src/services/backingImage.js
+++ b/src/services/backingImage.js
@@ -17,7 +17,7 @@ export async function execAction(url, params) {
   })
 }
 
-export async function queryBbiList() {
+export async function queryBackupBackingImageList() {
   return request({
     url: '/v1/backupbackingimages',
     method: 'get',

--- a/src/services/backingImage.js
+++ b/src/services/backingImage.js
@@ -17,7 +17,7 @@ export async function execAction(url, params) {
   })
 }
 
-export async function queryBackupBackingImage() {
+export async function queryBbiList() {
   return request({
     url: '/v1/backupbackingimages',
     method: 'get',

--- a/src/utils/dataDependency.js
+++ b/src/utils/dataDependency.js
@@ -72,6 +72,9 @@ const dependency = {
     }, {
       ns: 'setting',
       key: 'settings',
+    }, {
+      ns: 'backup',
+      key: 'backup',
     }],
   },
   settings: {
@@ -160,7 +163,7 @@ const httpDataDependency = {
   '/volume': ['volume', 'host', 'setting', 'backingImage', 'engineimage', 'recurringJob', 'backup'],
   '/engineimage': ['engineimage'],
   '/recurringJob': ['recurringJob'],
-  '/backingImage': ['volume', 'backingImage', 'setting'],
+  '/backingImage': ['volume', 'backingImage', 'setting', 'backup'],
   '/setting': ['setting'],
   '/backup': ['host', 'setting', 'backingImage', 'backup'],
   '/instanceManager': ['volume', 'instanceManager'],

--- a/src/utils/dataDependency.js
+++ b/src/utils/dataDependency.js
@@ -76,9 +76,6 @@ const dependency = {
     }, {
       ns: 'setting',
       key: 'settings',
-    }, {
-      ns: 'backup',
-      key: 'backup',
     }],
   },
   settings: {
@@ -170,7 +167,7 @@ const httpDataDependency = {
   '/volume': ['volume', 'host', 'setting', 'backingImage', 'engineimage', 'recurringJob', 'backup'],
   '/engineimage': ['engineimage'],
   '/recurringJob': ['recurringJob'],
-  '/backingImage': ['volume', 'backingImage', 'setting', 'backup'],
+  '/backingImage': ['volume', 'backingImage', 'setting'],
   '/setting': ['setting'],
   '/backup': ['host', 'setting', 'backingImage', 'backup'],
   '/instanceManager': ['volume', 'instanceManager'],
@@ -186,7 +183,6 @@ export function getDataDependency(pathName) {
     }
     return false
   })
-  // console.log('🚀 ~ keys ~ keys:', keys)
 
   if (keys && keys.length === 1) {
     let modal = dependency[keys[0]]

--- a/src/utils/dataDependency.js
+++ b/src/utils/dataDependency.js
@@ -1,3 +1,4 @@
+// key is the payload type, see model/app.js subscriptions()
 const dependency = {
   dashboard: {
     path: '/dashboard',
@@ -70,6 +71,9 @@ const dependency = {
       ns: 'backingImage',
       key: 'backingimages',
     }, {
+      ns: 'backingImage',
+      key: 'backupbackingimages',
+    }, {
       ns: 'setting',
       key: 'settings',
     }, {
@@ -138,6 +142,9 @@ const list = [{
   ns: 'backingImage',
   key: 'backingimages',
 }, {
+  ns: 'backingImage',
+  key: 'backupbackingimages',
+}, {
   ns: 'engineimage',
   key: 'engineimages',
 }, {
@@ -179,18 +186,15 @@ export function getDataDependency(pathName) {
     }
     return false
   })
+  // console.log('🚀 ~ keys ~ keys:', keys)
 
   if (keys && keys.length === 1) {
     let modal = dependency[keys[0]]
     modal.stopWs = list.filter((item) => {
-      return modal.runWs.every((ele) => {
-        return ele.ns !== item.ns
-      })
+      return modal.runWs.every((ele) => ele.ns !== item.ns)
     })
-
     return dependency[keys[0]]
   }
-
   return null
 }
 

--- a/src/utils/sort.js
+++ b/src/utils/sort.js
@@ -46,7 +46,7 @@ export function sortVolume(dataSource) {
   })
 }
 
-export function sortSnapshots(dataSource) {
+export function sortByCreatedTime(dataSource) {
   dataSource && dataSource.sort((a, b) => {
     return new Date(b.created).getTime() - new Date(a.created).getTime()
   })

--- a/src/utils/websocket.js
+++ b/src/utils/websocket.js
@@ -20,7 +20,6 @@ export function constructWebsocketURL(type, period) {
 }
 
 export function wsChanges(dispatch, type, period, ns, search) {
-  console.log('🚀 ~ wsChanges ~ type:', type)
   const url = constructWebsocketURL(type, period)
   const options = {
     timeout: 4000,
@@ -77,9 +76,6 @@ export function wsChanges(dispatch, type, period, ns, search) {
   }, 30000)
   // TODO: can refactor this to use a single event listener and dispatch to the correct action
   rws.addEventListener('message', (msg) => {
-    if (ns === 'backingImage') {
-      console.log('message rws.addEventListener ~ type =', backupType, ' msg:', JSON.parse(msg.data))
-    }
     recentWrite = true
     if (ns === 'backup') {
       if (backupType === 'backupvolumes') {
@@ -95,16 +91,13 @@ export function wsChanges(dispatch, type, period, ns, search) {
         })
       }
     } else if (ns === 'backingImage') {
-      console.log('message data ns:', ns, 'backupType:', backupType)
       if (backupType === 'backingimages') {
-        console.log('message backupType === backingimages call ns/updateBackground', JSON.parse(msg.data).data)
         dispatch({
           type: `${ns}/updateBackground`,
           payload: JSON.parse(msg.data),
         })
       }
       if (backupType === 'backupbackingimages') {
-        console.log('message backupType === backupbackingimages call ns/updateBackgroundBBi', JSON.parse(msg.data).data)
         dispatch({
           type: `${ns}/updateBackgroundBBi`,
           payload: JSON.parse(msg.data),


### PR DESCRIPTION
### What this PR does / why we need it

- [x] Add a backupBackingImage table in backing image page
- [x] Backup backing image allows two operations : delete and restore 
- [x] Add `Backup` action for each backing image to do backup action
- [x] Add bulk `Delete` action on top of backup backing image table
- [x] Add bulk `Backup` action on top of backing image table
- [x] Add Search box for backup backing image table
- [x] Allow input secret / secretNamespace when restoring bbi

Other minor changes
- Add BackupBackingImages websocket icon on the right bottom corner
- Refactor duplicated logic to single one function
- Fix typo
 
### Issue

[[FEATURE] Add BackupBackingImage UI](https://github.com/longhorn/longhorn/issues/7541)
[[UI][FEATURE] Add backing image encryption and clone support](https://github.com/longhorn/longhorn/issues/8789)

### Test Result

**Backup BI and restore BBI**

https://github.com/longhorn/longhorn-ui/assets/5744158/58e74eb8-197d-40db-be15-421a7c0c72fb


**Search BI and BBI tables**


https://github.com/longhorn/longhorn-ui/assets/5744158/34ecab14-4d12-430e-95ca-55ffffd6fb2e

**Bulk backup BI**

https://github.com/longhorn/longhorn-ui/assets/5744158/f26a8f47-b9e6-43dd-96b7-b0049f37a31f



### Additional documentation or context

Try this PR using `a110605/longhorn-ui:0709issue7541amd64`