### PR TITLE
Fix unneeded API call got 405 error

### DIFF
--- a/src/routes/volume/detail/Snapshots.js
+++ b/src/routes/volume/detail/Snapshots.js
@@ -36,6 +36,7 @@ class Snapshots extends React.Component {
           ...this.state,
           createBackModalVisible: true,
         })
+        return
       }
       if (action.type === 'toggleShowRemoved') {
         this.props.dispatch({
@@ -43,6 +44,7 @@ class Snapshots extends React.Component {
           payload: !this.props.showRemoved,
         })
         this.refs.Snapshot.showReomve()
+        return
       }
       if (action.type === 'snapshotBackup') {
         this.setState({
@@ -52,6 +54,7 @@ class Snapshots extends React.Component {
           snapshotBackupUrl: action.payload && action.payload.volume && action.payload.volume.actions && action.payload.volume.actions.snapshotBackup ? action.payload.volume.actions.snapshotBackup : '',
           snapshotListUrl: action.payload && action.payload.volume && action.payload.volume.actions && action.payload.volume.actions.snapshotList ? action.payload.volume.actions.snapshotList : '',
         })
+        return
       }
 
       let additionalActions = []


### PR DESCRIPTION
### What this PR does / why we need it

Previous PR mis-delete return in [this.onAction](https://github.com/longhorn/longhorn-ui/pull/760/files#diff-7e98dd20e7b18ef4b96415623c58922f7ef932ca1961d9debda71816a62c2cc0). It causes the code goes to dispatch `snapshotModal/snapshotAction` which is unexpected.

<img width="1489" alt="Screenshot 2024-07-02 at 9 38 35 PM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/0cfbae58-db1b-421b-a476-5e18df90be4d">

**Reproduce Steps**
 - go to volume details page
 - click `Create Backup`

### Issue
https://github.com/longhorn/longhorn/issues/8741

### Test Result

**Fixed**

https://github.com/longhorn/longhorn-ui/assets/5744158/108fda1b-ba51-460f-b53b-bb30fc5374fe


### Additional documentation or context
