### PR TITLE
Disable data engine when cloning volume

### DIFF
--- a/src/routes/volume/BulkCloneVolumeModal.js
+++ b/src/routes/volume/BulkCloneVolumeModal.js
@@ -161,7 +161,6 @@ const modal = ({
   const handleDataLocalityChange = (value) => updateVolumeConfig('dataLocality', value)
   const handleAccessModeChange = (value) => updateVolumeConfig('accessMode', value)
   const handleEncryptedCheck = (e) => updateVolumeConfig('encrypted', e.target.checked)
-  const handleDataEngineChange = (value) => updateVolumeConfig('dataEngine', value)
   const handleNodeTagRemove = (value) => {
     const oldNodeTags = volumeConfigs[tabIndex]?.nodeSelector
     const newNodeSelector = oldNodeTags?.filter(tag => tag !== value) || []
@@ -346,7 +345,7 @@ const modal = ({
                 },
               },
             ],
-          })(<Select onSelect={handleDataEngineChange}>
+          })(<Select disabled>
             <Option key={'v1'} value={'v1'}>v1</Option>
             <Option key={'v2'} value={'v2'}>v2</Option>
           </Select>)}

--- a/src/routes/volume/CloneVolume.js
+++ b/src/routes/volume/CloneVolume.js
@@ -219,7 +219,7 @@ const modal = ({
                 },
               },
             ],
-          })(<Select>
+          })(<Select disabled>
             <Option key={'v1'} value={'v1'}>v1</Option>
             <Option key={'v2'} value={'v2'}>v2</Option>
           </Select>)}


### PR DESCRIPTION
### What this PR does / why we need it

From demo feedback, disable `data engine` when cloning volume.

### Issue
https://github.com/longhorn/longhorn/issues/8741

### Test Result

**Single Clone Volume**
<img width="1285" alt="Screenshot 2024-07-03 at 11 14 11 AM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/543503f7-4dbb-44fb-8a25-b62ee18b3e3a">

**Bulk Clone Volume**

<img width="1209" alt="Screenshot 2024-07-03 at 11 14 47 AM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/cbc985dd-08f8-4725-ac86-a4ded3a38a00">

### Additional documentation or context
