### PR TITLE
 Add new feilds to backing image table and creation modal 

### DIFF
--- a/src/models/backingImage.js
+++ b/src/models/backingImage.js
@@ -1,5 +1,4 @@
-
-import { create, deleteBackingImage, query, deleteDisksOnBackingImage, uploadChunk, download, bulkDownload } from '../services/backingImage'
+import { create, deleteBackingImage, execAction, query, deleteDisksOnBackingImage, uploadChunk, download, bulkDownload } from '../services/backingImage'
 import { getNodeTags, getDiskTags } from '../services/volume'
 import { message, notification } from 'antd'
 import { delay } from 'dva/saga'
@@ -18,6 +17,7 @@ export default {
     nodeTags: [],
     diskTags: [],
     tagsLoading: true,
+    minCopiesCountModalVisible: false,
     createBackingImageModalVisible: false,
     createBackingImageModalKey: Math.random(),
     diskStateMapDetailModalVisible: false,
@@ -110,6 +110,13 @@ export default {
       payload,
     }, { call, put }) {
       yield call(deleteBackingImage, payload)
+      yield put({ type: 'query' })
+    },
+    *updateMinCopiesCount({
+      payload,
+    }, { call, put }) {
+      yield put({ type: 'hideUpdateMinCopiesCountModal' })
+      yield call(execAction, payload.url, payload.params)
       yield put({ type: 'query' })
     },
     *downloadBackingImage({
@@ -208,6 +215,13 @@ export default {
     showCreateBackingImageModal(state, action) {
       return { ...state, ...action.payload, createBackingImageModalVisible: true, createBackingImageModalKey: Math.random() }
     },
+    showUpdateMinCopiesCountModal(state, action) {
+      return {
+        ...state,
+        minCopiesCountModalVisible: true,
+        selected: action.payload,
+      }
+    },
     hideCreateBackingImageModal(state) {
       return { ...state, createBackingImageModalVisible: false }
     },
@@ -217,6 +231,13 @@ export default {
         selected: action.payload.record,
         diskStateMapDetailModalVisible: true,
         diskStateMapDetailModalKey: Math.random(),
+      }
+    },
+    hideUpdateMinCopiesCountModal(state) {
+      return {
+        ...state,
+        minCopiesCountModalVisible: false,
+        selected: {},
       }
     },
     hideDiskStateMapDetailModal(state) {

--- a/src/routes/backingImage/BackingImageActions.js
+++ b/src/routes/backingImage/BackingImageActions.js
@@ -5,7 +5,7 @@ import { DropOption } from '../../components'
 import { hasReadyBackingDisk } from '../../utils/status'
 const confirm = Modal.confirm
 
-function actions({ selected, deleteBackingImage, downloadBackingImage }) {
+function actions({ selected, deleteBackingImage, downloadBackingImage, showUpdateMinCopiesCount }) {
   const handleMenuClick = (event, record) => {
     event.domEvent?.stopPropagation?.()
     switch (event.key) {
@@ -20,6 +20,9 @@ function actions({ selected, deleteBackingImage, downloadBackingImage }) {
       case 'download':
         downloadBackingImage(record)
         break
+      case 'updateMinCopies':
+        showUpdateMinCopiesCount(record)
+        break
       default:
     }
   }
@@ -27,8 +30,9 @@ function actions({ selected, deleteBackingImage, downloadBackingImage }) {
   const disableDownloadAction = !hasReadyBackingDisk(selected)
 
   const availableActions = [
-    { key: 'delete', name: 'Delete' },
+    { key: 'updateMinCopies', name: 'Update Minimum Copies Count', disabled: disableDownloadAction, tooltip: disableDownloadAction ? 'Missing disk with ready state' : '' },
     { key: 'download', name: 'Download', disabled: disableDownloadAction, tooltip: disableDownloadAction ? 'Missing disk with ready state' : '' },
+    { key: 'delete', name: 'Delete' },
   ]
 
   return (
@@ -42,6 +46,7 @@ actions.propTypes = {
   selected: PropTypes.object,
   deleteBackingImage: PropTypes.func,
   downloadBackingImage: PropTypes.func,
+  showUpdateMinCopiesCount: PropTypes.func,
 }
 
 export default actions

--- a/src/routes/backingImage/BackingImageList.js
+++ b/src/routes/backingImage/BackingImageList.js
@@ -1,14 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Table, Button, Icon, Tooltip } from 'antd'
+import { Table, Button, Icon, Tooltip, Tag } from 'antd'
 import BackingImageActions from './BackingImageActions'
 import { pagination } from '../../utils/page'
 import { formatMib } from '../../utils/formatter'
+import { nodeTagColor, diskTagColor } from '../../utils/constants'
 
-function list({ loading, dataSource, deleteBackingImage, showDiskStateMapDetail, rowSelection, downloadBackingImage, height }) {
+function list({ loading, dataSource, deleteBackingImage, showDiskStateMapDetail, rowSelection, downloadBackingImage, showUpdateMinCopiesCount, height }) {
   const backingImageActionsProps = {
     deleteBackingImage,
     downloadBackingImage,
+    showUpdateMinCopiesCount,
   }
   const state = (record) => {
     if (record.deletionTimestamp) {
@@ -26,7 +28,7 @@ function list({ loading, dataSource, deleteBackingImage, showDiskStateMapDetail,
       title: 'Name',
       dataIndex: 'name',
       key: 'name',
-      width: 200,
+      width: 150,
       sorter: (a, b) => a.name.localeCompare(b.name),
       render: (text, record) => {
         return (
@@ -39,7 +41,7 @@ function list({ loading, dataSource, deleteBackingImage, showDiskStateMapDetail,
       title: 'UUID',
       dataIndex: 'uuid',
       key: 'uuid',
-      width: 150,
+      width: 120,
       sorter: (a, b) => a.uuid.localeCompare(b.uuid),
       render: (text) => {
         return (
@@ -50,7 +52,7 @@ function list({ loading, dataSource, deleteBackingImage, showDiskStateMapDetail,
       title: 'Size',
       dataIndex: 'size',
       key: 'size',
-      width: 150,
+      width: 80,
       sorter: (a, b) => a.size - b.size,
       render: (text) => {
         return (
@@ -59,16 +61,73 @@ function list({ loading, dataSource, deleteBackingImage, showDiskStateMapDetail,
           </div>
         )
       },
-    }, {
+    },
+    {
       title: 'Created From',
       dataIndex: 'sourceType',
       key: 'sourceType',
-      width: 200,
+      width: 150,
       sorter: (a, b) => a.sourceType.localeCompare(b.sourceType),
       render: (text) => {
         return (
           <div>
             {text}
+          </div>
+        )
+      },
+    }, {
+      title: 'Minimum Copies',
+      dataIndex: 'minNumberOfCopies',
+      key: 'minNumberOfCopies',
+      width: 120,
+      sorter: (a, b) => a.minNumberOfCopies.toString().localeCompare(b.minNumberOfCopies.toString()),
+      render: (text) => {
+        return (
+          <div>
+            {text}
+          </div>
+        )
+      },
+    }, {
+      title: 'Node Tags',
+      key: 'nodeSelector',
+      dataIndex: 'nodeSelector',
+      width: 120,
+      render: (_text, record) => {
+        const nodeTags = record.nodeSelector?.map((tag, index) => {
+          return (
+              <span style={{ marginBottom: '6px' }} key={index}>
+                <Tag color={nodeTagColor}>
+                  {tag}
+                </Tag>
+              </span>
+          )
+        }) || ''
+        return (
+          <div style={{ display: 'flex', justifyContent: 'space-between', flexDirection: 'column', alignItems: 'center' }}>
+            {nodeTags}
+          </div>
+        )
+      },
+    },
+    {
+      title: 'Disk Tags',
+      key: 'diskSelector',
+      dataIndex: 'diskSelector',
+      width: 120,
+      render: (_text, record) => {
+        const diskTags = record.diskSelector?.sort().map((tag, index) => {
+          return (
+              <span style={{ marginBottom: '6px' }} key={index}>
+                <Tag color={diskTagColor}>
+                  {tag}
+                </Tag>
+              </span>
+          )
+        }) || ''
+        return (
+          <div style={{ display: 'flex', justifyContent: 'space-between', flexDirection: 'column', alignItems: 'center' }}>
+            {diskTags}
           </div>
         )
       },
@@ -107,6 +166,7 @@ list.propTypes = {
   dataSource: PropTypes.array,
   deleteBackingImage: PropTypes.func,
   showDiskStateMapDetail: PropTypes.func,
+  showUpdateMinCopiesCount: PropTypes.func,
   rowSelection: PropTypes.object,
   height: PropTypes.number,
 }

--- a/src/routes/backingImage/CreateBackingImage.js
+++ b/src/routes/backingImage/CreateBackingImage.js
@@ -197,7 +197,7 @@ const modal = ({
           })(<Input placeholder="Ask Longhorn to validate the SHA512 checksum if it is specified here." />)}
         </FormItem>
         <FormItem label="Minimum Number of Copies" {...formItemLayout}>
-          {getFieldDecorator('MinNumberOfCopies', {
+          {getFieldDecorator('minNumberOfCopies', {
             initialValue: defaultNumberOfReplicas,
             rules: [
               {

--- a/src/routes/backingImage/UpdateMinCopiesCount.js
+++ b/src/routes/backingImage/UpdateMinCopiesCount.js
@@ -1,0 +1,76 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Form, InputNumber } from 'antd'
+import { ModalBlur } from '../../components'
+
+const FormItem = Form.Item
+
+const formItemLayout = {
+  labelCol: {
+    span: 12,
+  },
+  wrapperCol: {
+    span: 12,
+  },
+}
+
+const modal = ({
+  item,
+  defaultNumberOfReplicas,
+  visible,
+  onCancel,
+  onOk,
+  form: {
+    getFieldDecorator,
+    validateFields,
+    getFieldValue,
+  },
+}) => {
+  function handleOk() {
+    validateFields((errors) => {
+      if (errors) {
+        return
+      }
+      const minNumberOfCopies = getFieldValue('minNumberOfCopies')
+      onOk(item, minNumberOfCopies)
+    })
+  }
+
+  const modalOpts = {
+    title: 'Update Minimum Copies Count',
+    visible,
+    onCancel,
+    onOk: handleOk,
+  }
+  if (!item) {
+    return null
+  }
+  return (
+    <ModalBlur {...modalOpts}>
+      <Form layout="horizontal">
+        <FormItem label="Minimum Number of Copies" hasFeedback {...formItemLayout}>
+          {getFieldDecorator('minNumberOfCopies', {
+            initialValue: item.minNumberOfCopies || defaultNumberOfReplicas,
+            rules: [
+              {
+                required: true,
+                message: 'Please input the copies number',
+              },
+            ],
+          })(<InputNumber min={1} />)}
+        </FormItem>
+      </Form>
+    </ModalBlur>
+  )
+}
+
+modal.propTypes = {
+  defaultNumberOfReplicas: PropTypes.number,
+  form: PropTypes.object.isRequired,
+  visible: PropTypes.bool,
+  onCancel: PropTypes.func,
+  item: PropTypes.object,
+  onOk: PropTypes.func,
+}
+
+export default Form.create()(modal)

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -67,10 +67,17 @@ class BackingImage extends React.Component {
   render() {
     const { dispatch, loading, location } = this.props
     const { uploadFile } = this
+    const { data: settingData } = this.props.setting
     const { data: volumeData } = this.props.volume
-    const { data, selected, createBackingImageModalVisible, createBackingImageModalKey, diskStateMapDetailModalVisible, diskStateMapDetailModalKey, diskStateMapDeleteDisabled, diskStateMapDeleteLoading, selectedDiskStateMapRows, selectedDiskStateMapRowKeys, selectedRows } = this.props.backingImage
+    const { data, selected, nodeTags, diskTags, tagsLoading, createBackingImageModalVisible, createBackingImageModalKey, diskStateMapDetailModalVisible, diskStateMapDetailModalKey, diskStateMapDeleteDisabled, diskStateMapDeleteLoading, selectedDiskStateMapRows, selectedDiskStateMapRowKeys, selectedRows } = this.props.backingImage
+    console.log('🚀 ~ BackingImage ~ render ~ tagsLoading:', tagsLoading)
+    console.log('🚀 ~ BackingImage ~ render ~ diskTags:', diskTags)
+    console.log('🚀 ~ BackingImage ~ render ~ nodeTags:', nodeTags)
     const { backingImageUploadPercent, backingImageUploadStarted } = this.props.app
     const { field, value, createdFromValue } = queryString.parse(this.props.location.search)
+
+    const defaultReplicaCount = settingData.find(s => s.id === 'default-replica-count')
+    const defaultNumberOfReplicas = defaultReplicaCount ? parseInt(defaultReplicaCount.value, 10) : 3
 
     let backingImages = data
     if (field && (value || createdFromValue)) {
@@ -130,7 +137,7 @@ class BackingImage extends React.Component {
 
     const addBackingImage = () => {
       dispatch({
-        type: 'backingImage/showCreateBackingImageModal',
+        type: 'backingImage/openCreateBackingImageModal',
       })
     }
 
@@ -140,7 +147,11 @@ class BackingImage extends React.Component {
         url: '',
       },
       volumeNameOptions,
+      defaultNumberOfReplicas,
       visible: createBackingImageModalVisible,
+      nodeTags,
+      diskTags,
+      tagsLoading,
       onOk(newBackingImage) {
         let params = {}
         params.name = newBackingImage.name
@@ -167,6 +178,10 @@ class BackingImage extends React.Component {
           }
         }
         params.expectedChecksum = newBackingImage.expectedChecksum
+
+        params.diskSelector = newBackingImage.diskSelector
+        params.nodeSelector = newBackingImage.nodeSelector
+        params.minNumberOfCopies = newBackingImage.minNumberOfCopies
 
         dispatch({
           type: 'backingImage/create',
@@ -322,6 +337,7 @@ class BackingImage extends React.Component {
 
 BackingImage.propTypes = {
   app: PropTypes.object,
+  setting: PropTypes.object,
   backingImage: PropTypes.object,
   loading: PropTypes.bool,
   location: PropTypes.object,
@@ -329,4 +345,4 @@ BackingImage.propTypes = {
   dispatch: PropTypes.func,
 }
 
-export default connect(({ app, volume, backingImage, loading }) => ({ app, volume, backingImage, loading: loading.models.backingImage }))(BackingImage)
+export default connect(({ app, setting, volume, backingImage, loading }) => ({ app, setting, volume, backingImage, loading: loading.models.backingImage }))(BackingImage)

--- a/src/routes/host/DiskList.js
+++ b/src/routes/host/DiskList.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Table, Progress, Tooltip, Tag } from 'antd'
 import { byteToGi, getStorageProgressStatus } from './helper/index'
+import { diskTagColor } from '../../utils/constants'
 import { formatMib } from '../../utils/formatter'
 import './DiskList.less'
 
@@ -144,7 +145,7 @@ function diskList({ disks, node, storageOverProvisioningPercentage, minimalSched
         let forMap = (tag, index) => {
           return (
             <span style={{ marginBottom: '6px' }} key={index}>
-              <Tag color="#108eb9">
+              <Tag color={diskTagColor}>
                 {tag}
               </Tag>
             </span>

--- a/src/routes/host/HostList.js
+++ b/src/routes/host/HostList.js
@@ -12,7 +12,7 @@ import { byteToGi, getStorageProgressStatus } from './helper/index'
 import { formatMib } from '../../utils/formatter'
 import { pagination } from '../../utils/page'
 import { ModalBlur } from '../../components'
-import C from '../../utils/constants'
+import C, { nodeTagColor } from '../../utils/constants'
 
 class List extends React.Component {
   constructor(props) {
@@ -353,7 +353,7 @@ class List extends React.Component {
           let forMap = (tag, index) => {
             return (
               <span style={{ marginBottom: '6px' }} key={index}>
-                <Tag color="rgb(39, 174, 95)">
+                <Tag color={nodeTagColor}>
                   {tag}
                 </Tag>
               </span>

--- a/src/routes/host/components/TagComponent.js
+++ b/src/routes/host/components/TagComponent.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Tag, Input, Tooltip, Icon } from 'antd'
+import { nodeTagColor, diskTagColor } from '../../../utils/constants'
 
 class DistTag extends React.Component {
   state = {
@@ -49,7 +50,7 @@ class DistTag extends React.Component {
         {tags.map((tag) => {
           const isLongTag = tag.length > 20
           const tagElem = (
-            <Tag color={this.props.nodeBoolean ? 'rgb(39, 174, 95)' : '#108eb9'} key={tag} closable onClose={() => this.handleClose(tag)}>
+            <Tag color={this.props.nodeBoolean ? nodeTagColor : diskTagColor} key={tag} closable onClose={() => this.handleClose(tag)}>
               {isLongTag ? `${tag.slice(0, 20)}...` : tag}
             </Tag>
           )

--- a/src/routes/volume/detail/VolumeInfo.js
+++ b/src/routes/volume/detail/VolumeInfo.js
@@ -14,6 +14,7 @@ import {
   getOfflineRebuiltStatusWithoutFrontend,
 } from '../helper/index'
 import styles from './VolumeInfo.less'
+import { diskTagColor, nodeTagColor } from '../../../utils/constants'
 import { EngineImageUpgradeTooltip, ReplicaHATooltip } from '../../../components'
 import ConditionTooltip from './ConditionTooltip'
 import { isVolumeImageUpgradable, isVolumeReplicaNotRedundancy, isVolumeRelicaLimited } from '../../../utils/filter'
@@ -102,7 +103,7 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
 
   let forMapNode = (tag, index) => {
     return (
-      <Tag key={index} color="rgb(39, 174, 95)">
+      <Tag key={index} color={nodeTagColor}>
         {tag}
       </Tag>
     )
@@ -110,7 +111,7 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
 
   let forMapDisk = (tag, index) => {
     return (
-      <Tag key={index} color="#108eb9">
+      <Tag key={index} color={diskTagColor}>
         {tag}
       </Tag>
     )

--- a/src/routes/volume/index.js
+++ b/src/routes/volume/index.js
@@ -219,6 +219,7 @@ class Volume extends React.Component {
     const { field, value, stateValue, nodeRedundancyValue, engineImageUpgradableValue, scheduleValue, pvStatusValue, revisionCounterValue } = queryString.parse(this.props.location.search)
     const settings = this.props.setting.data
     const defaultReplicaCountSetting = settings.find(s => s.id === 'default-replica-count')
+    console.log('🚀 ~ Volume ~ render ~ defaultReplicaCountSetting:', defaultReplicaCountSetting)
     const defaultDataLocalitySetting = settings.find(s => s.id === 'default-data-locality')
     const defaultSnapshotDataIntegritySetting = settings.find(s => s.id === 'snapshot-data-integrity')
     const defaultRevisionCounterSetting = settings.find(s => s.id === 'disable-revision-counter')

--- a/src/routes/volume/index.js
+++ b/src/routes/volume/index.js
@@ -219,7 +219,6 @@ class Volume extends React.Component {
     const { field, value, stateValue, nodeRedundancyValue, engineImageUpgradableValue, scheduleValue, pvStatusValue, revisionCounterValue } = queryString.parse(this.props.location.search)
     const settings = this.props.setting.data
     const defaultReplicaCountSetting = settings.find(s => s.id === 'default-replica-count')
-    console.log('🚀 ~ Volume ~ render ~ defaultReplicaCountSetting:', defaultReplicaCountSetting)
     const defaultDataLocalitySetting = settings.find(s => s.id === 'default-data-locality')
     const defaultSnapshotDataIntegritySetting = settings.find(s => s.id === 'snapshot-data-integrity')
     const defaultRevisionCounterSetting = settings.find(s => s.id === 'disable-revision-counter')

--- a/src/services/backingImage.js
+++ b/src/services/backingImage.js
@@ -19,6 +19,14 @@ export async function create(params) {
   })
 }
 
+export async function execAction(url, params) {
+  return request({
+    url,
+    method: 'post',
+    data: params,
+  })
+}
+
 export async function deleteBackingImage(params) {
   if (params.actions && params.actions.backingImageCleanup) {
     return request({

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -8,5 +8,8 @@ const C = {
   ContainerMarginHeight: 101,
 }
 
+const nodeTagColor = 'rgb(39, 174, 95)' // green
+const diskTagColor = '#108eb9' // blue
+
 export default C
-export { LH_UI_VERSION }
+export { LH_UI_VERSION, nodeTagColor, diskTagColor }

--- a/src/utils/dataDependency.js
+++ b/src/utils/dataDependency.js
@@ -69,6 +69,9 @@ const dependency = {
     }, {
       ns: 'backingImage',
       key: 'backingimages',
+    }, {
+      ns: 'setting',
+      key: 'settings',
     }],
   },
   settings: {
@@ -157,7 +160,7 @@ const httpDataDependency = {
   '/volume': ['volume', 'host', 'setting', 'backingImage', 'engineimage', 'recurringJob', 'backup'],
   '/engineimage': ['engineimage'],
   '/recurringJob': ['recurringJob'],
-  '/backingImage': ['volume', 'backingImage'],
+  '/backingImage': ['volume', 'backingImage', 'setting'],
   '/setting': ['setting'],
   '/backup': ['host', 'setting', 'backingImage', 'backup'],
   '/instanceManager': ['volume', 'instanceManager'],


### PR DESCRIPTION
### What this PR does / why we need it

 - [x] add minNumberOfCopies / Disk Tag / Node Tag in creating backing image modal
 - [x] allow edit backing image minNumberOfCopies
 - [x] show minNumberOfCopies / Disk Tag / Node Tag in backing image table
 - [x] allow search for minNumberOfCopies / Disk Tag / Node Tag in filter


### Issue
https://github.com/longhorn/longhorn/issues/8485
### Test Result

https://github.com/longhorn/longhorn-ui/assets/5744158/f9cb1282-107d-49a4-baa3-12a51386493b


### Additional documentation or context
