### PR TITLE
fix: bring backupMode in volume/bulkBackup payload

### DIFF
--- a/src/models/volume.js
+++ b/src/models/volume.js
@@ -472,7 +472,15 @@ export default {
     *bulkBackup({
       payload,
     }, { put }) {
-      yield payload.actions.map(item => put({ type: 'snapshotCreateThenBackup', payload: { snapshotCreateUrl: item.snapshotCreateUrl, snapshotBackupUrl: item.snapshotBackupUrl, labels: payload.labels } }))
+      yield payload.actions.map(item => put({
+        type: 'snapshotCreateThenBackup',
+        payload: {
+          snapshotCreateUrl: item.snapshotCreateUrl,
+          snapshotBackupUrl: item.snapshotBackupUrl,
+          labels: payload.labels,
+          backupMode: payload.backupMode,
+        },
+      }))
       yield put({ type: 'query' })
     },
     *createPVAndPVC({
@@ -571,7 +579,7 @@ export default {
       payload,
     }, { call }) {
       const snapshot = yield call(execAction, payload.snapshotCreateUrl, {})
-      yield call(execAction, payload.snapshotBackupUrl, { name: snapshot.name, labels: payload.labels })
+      yield call(execAction, payload.snapshotBackupUrl, { name: snapshot.name, labels: payload.labels, backupMode: payload.backupMode })
     },
     *createRecurringJob({
       payload,

--- a/src/routes/volume/index.js
+++ b/src/routes/volume/index.js
@@ -1046,11 +1046,6 @@ class Volume extends React.Component {
         })
       },
       bulkBackup(actions) {
-        // bulkBackup(actions.map(item => { return { snapshotCreateUrl: item.actions.snapshotCreate, snapshotBackupUrl: item.actions.snapshotBackup } }))
-        // dispatch({
-        //   type: 'volume/bulkBackup',
-        //   payload: actions,
-        // })
         me.setState({
           ...me.state,
           createBackModalKey: Math.random(),
@@ -1189,7 +1184,7 @@ class Volume extends React.Component {
           type: 'volume/bulkBackup',
           payload: {
             actions: me.state.selectedRows.map(item => { return { snapshotCreateUrl: item.actions.snapshotCreate, snapshotBackupUrl: item.actions.snapshotBackup } }),
-            labels: obj,
+            ...obj,
           },
         })
         me.setState({


### PR DESCRIPTION
### What this PR does / why we need it
In previous [PR](https://github.com/longhorn/longhorn-ui/pull/766), I didn't notice there is bulk `Create Backup` action in volume page, we should bring `backupMode` in payload as well.

### Issue
https://github.com/longhorn/longhorn/issues/8947


### Test Result

<img width="1496" alt="Screenshot 2024-07-08 at 3 11 50 PM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/6ed563da-eab7-4bf4-abd8-375821b7fd61">

<img width="1492" alt="Screenshot 2024-07-08 at 3 12 32 PM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/168dc421-c3bd-466f-b356-8e0eee3b6ae1">


### Additional documentation or context
