### PR TITLE
fix take backup from snapshot should bring backupMode in payload

### DIFF
--- a/src/models/snapshot.js
+++ b/src/models/snapshot.js
@@ -215,9 +215,9 @@ export default (namespace) => {
       }, { call, put }) {
         yield put({ type: 'setLoading', payload: true })
         if (Object.getOwnPropertyNames(payload.labels).length === 0) {
-          yield call(execAction, payload.snapshotBackupUrl, { name: payload.snapshotName })
+          yield call(execAction, payload.snapshotBackupUrl, { name: payload.snapshotName, backupMode: payload.backupMode })
         } else {
-          yield call(execAction, payload.snapshotBackupUrl, { name: payload.snapshotName, labels: payload.labels })
+          yield call(execAction, payload.snapshotBackupUrl, { name: payload.snapshotName, labels: payload.labels, backupMode: payload.backupMode })
         }
         yield put({ type: 'querySnapShot', payload: { url: payload.querySnapShotUrl } })
         yield put({ type: 'setLoading', payload: false })

--- a/src/routes/volume/detail/Snapshots.js
+++ b/src/routes/volume/detail/Snapshots.js
@@ -192,7 +192,7 @@ class Snapshots extends React.Component {
               snapshotBackupUrl: me.state.snapshotBackupUrl,
               snapshotName: me.state.currentSnapshotName,
               querySnapShotUrl: me.state.snapshotListUrl,
-              labels: data,
+              ...data,
             },
           })
           me.setState({


### PR DESCRIPTION
### What this PR does / why we need it
Same as https://github.com/longhorn/longhorn-ui/pull/768, should bring `backupMode` field in payload.

### Issue
[[BUG] Create backup from UI volume page failed](https://github.com/longhorn/longhorn/issues/8947)

### Test Result

https://github.com/longhorn/longhorn-ui/assets/5744158/52466c69-e8d1-42aa-a190-7858a3640a77



### Additional documentation or context
