### PR TITLE
show error message and disable buttons if backup target is not available

### DIFF
--- a/src/models/backup.js
+++ b/src/models/backup.js
@@ -102,11 +102,9 @@ export default {
     }, { call, put }) {
       const resp = yield call(queryTarget)
       if (resp && resp.data && resp.data[0]) {
-        let isbackupVolumePage = true
-        let path = ['/node', '/dashboard', '/volume', '/engineimage', '/setting', '/recurringJob']
-
-        isbackupVolumePage = payload.history && payload.history.location && payload.history.location.pathname && payload.history.location.pathname !== '/' && path.every(ele => !payload.history.location.pathname.startsWith(ele))
-        if (isbackupVolumePage) {
+        const backupNeededPages = ['/backup', '/backingImage', '/systemBackups']
+        const isBackupNeededPage = payload?.history?.location?.pathname && payload.history.location.pathname !== '/' && backupNeededPages.some(page => payload.history.location.pathname.startsWith(page))
+        if (isBackupNeededPage) {
           !resp.data[0].available ? message.error(resp.data[0].message) : message.destroy()
         }
         yield put({ type: 'setBackupTargetAvailable', payload: { backupTargetAvailable: resp.data[0].available, backupTargetMessage: resp.data[0].message } })

--- a/src/routes/backingImage/BackingImageActions.js
+++ b/src/routes/backingImage/BackingImageActions.js
@@ -5,7 +5,9 @@ import { DropOption } from '../../components'
 import { hasReadyBackingDisk } from '../../utils/status'
 const confirm = Modal.confirm
 
-function actions({ selected, deleteBackingImage, downloadBackingImage, showUpdateMinCopiesCount, createBackupBackingImage }) {
+function actions({ selected, backupProps, deleteBackingImage, downloadBackingImage, showUpdateMinCopiesCount, createBackupBackingImage }) {
+  const { backupTargetAvailable, backupTargetMessage } = backupProps
+
   const handleMenuClick = (event, record) => {
     event.domEvent?.stopPropagation?.()
     switch (event.key) {
@@ -34,9 +36,16 @@ function actions({ selected, deleteBackingImage, downloadBackingImage, showUpdat
 
   const disableAction = !hasReadyBackingDisk(selected)
 
+  const getBackupActionTooltip = () => {
+    if (!backupTargetAvailable) {
+      return backupTargetMessage
+    }
+    return disableAction ? 'Missing disk with ready state' : ''
+  }
+
   const availableActions = [
     { key: 'updateMinCopies', name: 'Update Minimum Copies Count', disabled: disableAction, tooltip: disableAction ? 'Missing disk with ready state' : '' },
-    { key: 'backup', name: ' Backup', disabled: disableAction, tooltip: disableAction ? 'Missing disk with ready state' : '' },
+    { key: 'backup', name: ' Backup', disabled: disableAction || backupTargetAvailable === false, tooltip: getBackupActionTooltip() },
     { key: 'download', name: 'Download', disabled: disableAction, tooltip: disableAction ? 'Missing disk with ready state' : '' },
     { key: 'delete', name: 'Delete' },
   ]
@@ -54,6 +63,7 @@ actions.propTypes = {
   downloadBackingImage: PropTypes.func,
   showUpdateMinCopiesCount: PropTypes.func,
   createBackupBackingImage: PropTypes.func,
+  backupProps: PropTypes.object,
 }
 
 export default actions

--- a/src/routes/backingImage/BackingImageBulkActions.js
+++ b/src/routes/backingImage/BackingImageBulkActions.js
@@ -6,7 +6,9 @@ import { hasReadyBackingDisk, diskStatusColorMap } from '../../utils/status'
 const confirm = Modal.confirm
 
 
-function bulkActions({ selectedRows, deleteBackingImages, downloadSelectedBackingImages, backupSelectedBackingImages }) {
+function bulkActions({ selectedRows, backupProps, deleteBackingImages, downloadSelectedBackingImages, backupSelectedBackingImages }) {
+  const { backupTargetAvailable } = backupProps
+
   const handleClick = (action) => {
     const count = selectedRows.length
     switch (action) {
@@ -90,7 +92,7 @@ function bulkActions({ selectedRows, deleteBackingImages, downloadSelectedBackin
   const allActions = [
     { key: 'delete', name: 'Delete', disabled() { return selectedRows.length === 0 } },
     { key: 'download', name: 'Download', disabled() { return (selectedRows.length === 0 || selectedRows.every(row => !hasReadyBackingDisk(row))) } },
-    { key: 'backup', name: 'Backup', disabled() { return selectedRows.length === 0 || selectedRows.every(row => !hasReadyBackingDisk(row)) } },
+    { key: 'backup', name: 'Backup', disabled() { return selectedRows.length === 0 || backupTargetAvailable === false || selectedRows.every(row => !hasReadyBackingDisk(row)) } },
   ]
 
   return (
@@ -111,6 +113,7 @@ bulkActions.propTypes = {
   deleteBackingImages: PropTypes.func,
   downloadSelectedBackingImages: PropTypes.func,
   backupSelectedBackingImages: PropTypes.func,
+  backupProps: PropTypes.object,
 }
 
 export default bulkActions

--- a/src/routes/backingImage/BackingImageList.js
+++ b/src/routes/backingImage/BackingImageList.js
@@ -6,12 +6,13 @@ import { pagination } from '../../utils/page'
 import { formatMib } from '../../utils/formatter'
 import { nodeTagColor, diskTagColor } from '../../utils/constants'
 
-function list({ loading, dataSource, deleteBackingImage, showDiskStateMapDetail, rowSelection, createBackupBackingImage, downloadBackingImage, showUpdateMinCopiesCount, height }) {
+function list({ loading, dataSource, backupProps, deleteBackingImage, showDiskStateMapDetail, rowSelection, createBackupBackingImage, downloadBackingImage, showUpdateMinCopiesCount, height }) {
   const backingImageActionsProps = {
     deleteBackingImage,
     downloadBackingImage,
     createBackupBackingImage,
     showUpdateMinCopiesCount,
+    backupProps,
   }
 
   const dynamicStateIcon = (record) => {
@@ -191,6 +192,7 @@ list.propTypes = {
   showUpdateMinCopiesCount: PropTypes.func,
   rowSelection: PropTypes.object,
   height: PropTypes.number,
+  backupProps: PropTypes.object,
 }
 
 export default list

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -196,6 +196,7 @@ class BackingImage extends React.Component {
     const backingImageListProps = {
       dataSource: backingImages,
       height: this.state.height,
+      backupProps: this.props.backup,
       loading,
       showUpdateMinCopiesCount(record) {
         dispatch({
@@ -408,6 +409,7 @@ class BackingImage extends React.Component {
 
     const backingImageBulkActionsProps = {
       selectedRows,
+      backupProps: this.props.backup,
       deleteBackingImages(record) {
         dispatch({
           type: 'backingImage/bulkDelete',
@@ -517,7 +519,8 @@ BackingImage.propTypes = {
   loading: PropTypes.bool,
   location: PropTypes.object,
   volume: PropTypes.object,
+  backup: PropTypes.object,
   dispatch: PropTypes.func,
 }
 
-export default connect(({ app, setting, volume, backingImage, loading }) => ({ app, setting, volume, backingImage, loading: loading.models.backingImage }))(BackingImage)
+export default connect(({ app, setting, backup, volume, backingImage, loading }) => ({ app, setting, volume, backup, backingImage, loading: loading.models.backingImage }))(BackingImage)

--- a/src/routes/systemBackups/index.js
+++ b/src/routes/systemBackups/index.js
@@ -104,6 +104,7 @@ class SystemBackups extends React.Component {
 
     const SystemBackupsBulkActionProps = {
       selectedRows: this.state.selectedSystemBackupsRows,
+      backupProps: this.props.backup,
       deleteSystemBackups() {
         dispatch({
           type: 'systemBackups/bulkDeleteSystemBackup',
@@ -263,7 +264,8 @@ SystemBackups.propTypes = {
   loading: PropTypes.bool,
   dispatch: PropTypes.func,
   systemBackups: PropTypes.object,
+  backup: PropTypes.object,
   location: PropTypes.object,
 }
 
-export default connect(({ systemBackups, loading }) => ({ systemBackups, loading: loading.models.systemBackups }))(SystemBackups)
+export default connect(({ systemBackups, backup, loading }) => ({ systemBackups, backup, loading: loading.models.systemBackups }))(SystemBackups)

--- a/src/routes/systemBackups/systemBackupsBulkActions.js
+++ b/src/routes/systemBackups/systemBackupsBulkActions.js
@@ -5,7 +5,7 @@ import style from './systemBackupsBulkActions.less'
 
 const confirm = Modal.confirm
 
-function bulkActions({ selectedRows, deleteSystemBackups, createSystemBackup }) {
+function bulkActions({ selectedRows, backupProps, deleteSystemBackups, createSystemBackup }) {
   const handleClick = (action) => {
     switch (action) {
       case 'create':
@@ -22,8 +22,10 @@ function bulkActions({ selectedRows, deleteSystemBackups, createSystemBackup }) 
       default:
     }
   }
+
+  const { backupTargetAvailable, backupTargetMessage } = backupProps
   const allActions = [
-    { key: 'create', name: 'Create' },
+    { key: 'create', name: 'Create', disabled: backupTargetAvailable === false, tooltip: backupTargetAvailable === false ? backupTargetMessage : '' },
     { key: 'delete', name: 'Delete', disabled: selectedRows.length === 0 },
   ]
 
@@ -43,6 +45,7 @@ function bulkActions({ selectedRows, deleteSystemBackups, createSystemBackup }) 
 
 bulkActions.propTypes = {
   selectedRows: PropTypes.array,
+  backupProps: PropTypes.object,
   deleteSystemBackups: PropTypes.func,
   createSystemBackup: PropTypes.func,
 }

--- a/src/utils/dataDependency.js
+++ b/src/utils/dataDependency.js
@@ -167,12 +167,12 @@ const httpDataDependency = {
   '/volume': ['volume', 'host', 'setting', 'backingImage', 'engineimage', 'recurringJob', 'backup'],
   '/engineimage': ['engineimage'],
   '/recurringJob': ['recurringJob'],
-  '/backingImage': ['volume', 'backingImage', 'setting'],
+  '/backingImage': ['volume', 'backingImage', 'setting', 'backup'],
   '/setting': ['setting'],
   '/backup': ['host', 'setting', 'backingImage', 'backup'],
   '/instanceManager': ['volume', 'instanceManager'],
   '/orphanedData': ['orphanedData'],
-  '/systemBackups': ['systemBackups'],
+  '/systemBackups': ['systemBackups', 'backup'],
 }
 
 export function getDataDependency(pathName) {


### PR DESCRIPTION
### What this PR does / why we need it
Since bbi table is added in backing image page in previous PR.

We should show `backup target URL is empty` error message in backup, backingImage or systemBackups pages and disable related buttons.

### Issue

https://github.com/longhorn/longhorn/issues/7541

### Test Result

Empty backuptarget

https://github.com/longhorn/longhorn-ui/assets/5744158/9ffd0baf-dd86-47c0-850e-2933ce673dea

Availalbe backuptarget

https://github.com/longhorn/longhorn-ui/assets/5744158/050b8273-fd14-4317-b472-de1a34271e39




### Additional documentation or context

If user input non-available backuptarget, couldn't connect it or typo.
The error msg too long to read. Maybe we can simple it to one sentence like `backup target is not available` cc @ChanYiLin 

<img width="1487" alt="Screenshot 2024-07-10 at 11 25 39 AM" src="https://github.com/longhorn/longhorn-ui/assets/5744158/b100c981-cce8-4708-a0da-89171d475dd0">

