### PR TITLE
Update backup wording and restore backing image modal

### DIFF
--- a/src/components/Snapshot/Snapshot.js
+++ b/src/components/Snapshot/Snapshot.js
@@ -103,9 +103,17 @@ function SnapshotIcon(props, snapshotProps) {
           </div>}><div className="disable-dropdown-menu">Revert</div></Tooltip> }
         </Menu.Item> : ''
       }
-      { props.usercreated && !snapshotObject.removed ? <Menu.Item key="snapshotBackup" className="revert-menu-item">
-          { !snapshotProps.disableBackup ? <div style={{ padding: '0px 12px' }}>Backup</div> : <Tooltip title={snapshotProps.disableBackupMessage}><div className="disable-dropdown-menu">Backup</div></Tooltip>}
-        </Menu.Item> : ''
+      { props.usercreated && !snapshotObject.removed ? (
+        <Menu.Item key="snapshotBackup" className="revert-menu-item">
+          { !snapshotProps.disableBackup ? (
+            <div style={{ padding: '0px 12px' }}>Back Up</div>
+          ) : (
+            <Tooltip title={snapshotProps.disableBackupMessage}>
+              <div className="disable-dropdown-menu">Back up</div>
+            </Tooltip>
+          )}
+        </Menu.Item>
+      ) : ''
       }
       <Menu.Item key="cloneVolumeFromSnapshot">
         <div style={{ padding: '0px 12px' }}>Clone Volume</div>

--- a/src/models/backingImage.js
+++ b/src/models/backingImage.js
@@ -90,7 +90,7 @@ export default {
       if (url) {
         const resp = yield call(execAction, url)
         if (resp && resp.status === 200) {
-          message.success(`Successfully backup ${payload.name} backing image`)
+          message.success(`Successfully back up ${payload.name} backing image`)
         }
         yield delay(1000)
         yield put({ type: 'queryBackupBackingImage' })

--- a/src/models/backingImage.js
+++ b/src/models/backingImage.js
@@ -90,7 +90,7 @@ export default {
       if (url) {
         const resp = yield call(execAction, url)
         if (resp && resp.status === 200) {
-          message.success(`Successfully back up ${payload.name} backing image`)
+          message.success(`Successfully backed up ${payload.name} backing image`)
         }
         yield delay(1000)
         yield put({ type: 'queryBackupBackingImage' })

--- a/src/routes/backingImage/BackingImageActions.js
+++ b/src/routes/backingImage/BackingImageActions.js
@@ -45,7 +45,7 @@ function actions({ selected, backupProps, deleteBackingImage, downloadBackingIma
 
   const availableActions = [
     { key: 'updateMinCopies', name: 'Update Minimum Copies Count', disabled: disableAction, tooltip: disableAction ? 'Missing disk with ready state' : '' },
-    { key: 'backup', name: ' Backup', disabled: disableAction || backupTargetAvailable === false, tooltip: getBackupActionTooltip() },
+    { key: 'backup', name: ' Back Up', disabled: disableAction || backupTargetAvailable === false, tooltip: getBackupActionTooltip() },
     { key: 'download', name: 'Download', disabled: disableAction, tooltip: disableAction ? 'Missing disk with ready state' : '' },
     { key: 'delete', name: 'Delete' },
   ]

--- a/src/routes/backingImage/BackingImageBulkActions.js
+++ b/src/routes/backingImage/BackingImageBulkActions.js
@@ -92,7 +92,7 @@ function bulkActions({ selectedRows, backupProps, deleteBackingImages, downloadS
   const allActions = [
     { key: 'delete', name: 'Delete', disabled() { return selectedRows.length === 0 } },
     { key: 'download', name: 'Download', disabled() { return (selectedRows.length === 0 || selectedRows.every(row => !hasReadyBackingDisk(row))) } },
-    { key: 'backup', name: 'Backup', disabled() { return selectedRows.length === 0 || backupTargetAvailable === false || selectedRows.every(row => !hasReadyBackingDisk(row)) } },
+    { key: 'backup', name: 'Back Up', disabled() { return selectedRows.length === 0 || backupTargetAvailable === false || selectedRows.every(row => !hasReadyBackingDisk(row)) } },
   ]
 
   return (

--- a/src/routes/backingImage/RestoreBackupBackingImageModal.js
+++ b/src/routes/backingImage/RestoreBackupBackingImageModal.js
@@ -39,7 +39,7 @@ const modal = ({
   }
 
   const modalOpts = {
-    title: `Restore ${item.name} Backup Backing Image`,
+    title: 'Restore Backing Image',
     visible,
     onCancel,
     onOk: handleOk,
@@ -50,16 +50,15 @@ const modal = ({
   return (
     <ModalBlur {...modalOpts}>
       <Form layout="horizontal">
-         <FormItem label="Secret" hasFeedback {...formItemLayout}>
-              {getFieldDecorator('secret', {
-                initialValue: '',
-              })(<Input />)}
-            </FormItem>
-            <FormItem label="Secret Namespace" hasFeedback {...formItemLayout}>
-              {getFieldDecorator('secretNamespace', {
-                initialValue: '',
-              })(<Input />)}
-            </FormItem>
+        <FormItem label="Backup" {...formItemLayout}>
+          {getFieldDecorator('backup', { initialValue: item?.name || '' })(<Input disabled />)}
+        </FormItem>
+        <FormItem label="Secret" hasFeedback {...formItemLayout}>
+          {getFieldDecorator('secret', { initialValue: '' })(<Input />)}
+        </FormItem>
+        <FormItem label="Secret Namespace" hasFeedback {...formItemLayout}>
+          {getFieldDecorator('secretNamespace', { initialValue: '' })(<Input />)}
+        </FormItem>
       </Form>
     </ModalBlur>
   )

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -482,7 +482,7 @@ class BackingImage extends React.Component {
         </div>
         <div className={style.backupBackingImageTitle}>
           <Icon type="file-image" className="ant-breadcrumb anticon" style={{ display: 'flex', alignItems: 'center' }} />
-          <span style={{ marginLeft: '4px' }}>Backup Backing Image</span>
+          <span style={{ marginLeft: '4px' }}>Backing Image Backup</span>
         </div>
         <div id="backupBackingImageTable" style={{ height: '45%', padding: '8px 12px 0px' }}>
           <Row gutter={24} style={{ marginBottom: 8 }}>


### PR DESCRIPTION
### What this PR does / why we need it
From doc review feedback, update the wordings. 
See https://github.com/longhorn/website/pull/943#issuecomment-2224851099

### Issue
https://github.com/longhorn/longhorn/issues/7541

### Test Result
<img width="1489" alt="Screenshot 2024-07-12 at 4 44 07 PM" src="https://github.com/user-attachments/assets/9ac6d33f-281a-4b6b-b15b-d3a5b8dbdb31">

<img width="1484" alt="Screenshot 2024-07-12 at 4 39 29 PM" src="https://github.com/user-attachments/assets/80e2ba8d-1dbd-4e1b-8674-6f549a5b35b7">

In volume detail page.
<img width="1477" alt="Screenshot 2024-07-12 at 4 20 52 PM" src="https://github.com/user-attachments/assets/670f52ae-b6a6-47b7-928a-60557ef641c3">


### Additional documentation or context
This PR should backport to v1.7.x

