### PR TITLE
ignore case sensitive when search in instance manager image page

### DIFF
--- a/src/models/instanceManager.js
+++ b/src/models/instanceManager.js
@@ -25,8 +25,10 @@ export default {
       payload,
     }, { call, put }) {
       const data = yield call(query, payload)
+      // filter data based on payload.field and payload.value
       if (payload && payload.field && payload.value && data.data) {
-        data.data = data.data.filter(item => item[payload.field] && item[payload.field].indexOf(payload.value.trim()) > -1)
+        const searchValue = payload.value.trim().toLowerCase()
+        data.data = data.data.filter(item => item[payload.field] && item[payload.field].toLowerCase().indexOf(searchValue) > -1)
       }
       if (data.data) {
         data.data.sort((a, b) => a.name.localeCompare(b.name))


### PR DESCRIPTION
### What this PR does / why we need it
The bug comes from currentState : "running" is lowercase. but user searches "Running"
 
Ignore case sensitive when search in instance manager image page

### Issue
https://github.com/longhorn/longhorn/issues/9010

### Test Result

https://github.com/user-attachments/assets/91005490-2f3a-4a5c-bd62-305a399d7bd6


### Additional documentation or context
Note. this PR need backport to v1.7.x once merged