### PR TITLE
filter out volume in restoring or not ready status when bulk clone volume

### DIFF
--- a/src/routes/volume/VolumeBulkActions.js
+++ b/src/routes/volume/VolumeBulkActions.js
@@ -193,7 +193,8 @@ function bulkActions({
     { key: 'attach', name: 'Attach', disabled() { return selectedRows.length === 0 || selectedRows.some((item) => !attachable(item)) } },
     { key: 'detach', name: 'Detach', disabled() { return selectedRows.length === 0 || selectedRows.some((item) => !detachable(item)) } },
     { key: 'backup', name: 'Create Backup', disabled() { return selectedRows.length === 0 || isSnapshotDisabled() || hasDoingState() || isHasStandy() || hasVolumeRestoring() || !backupTargetAvailable }, toolTip: backupTargetMessage },
-    { key: 'bulkCloneVolume', name: 'Clone Volume', disabled() { return selectedRows.length === 0 } },
+    { key: 'bulkCloneVolume', name: 'Clone Volume', disabled() { return selectedRows.length === 0 || selectedRows.every(item => item.standby || isRestoring(item)) } },
+
   ]
 
   const allDropDownActions = [

--- a/src/routes/volume/index.js
+++ b/src/routes/volume/index.js
@@ -39,6 +39,7 @@ import UpdateReplicaAutoBalanceModal from './UpdateReplicaAutoBalanceModal'
 import UpdateBulkDataLocality from './UpdateBulkDataLocality'
 import Salvage from './Salvage'
 import { Filter, ExpansionErrorDetail } from '../../components/index'
+import { isRestoring } from './helper'
 import VolumeBulkActions from './VolumeBulkActions'
 import {
   getAttachHostModalProps,
@@ -912,9 +913,8 @@ class Volume extends React.Component {
         })
       },
     }
-
     const bulkCloneVolumeModalProps = {
-      selectedRows,
+      selectedRows: selectedRows.filter(item => !item.standby && !isRestoring(item)), // filter out standby and restoring volumes
       visible: bulkCloneVolumeVisible,
       diskTags,
       nodeTags,


### PR DESCRIPTION
### What this PR does / why we need it
- filter out volumes in restoring or not ready status when click bulk clone volume
- disable bulk clone volume button if all selected vols are in restoring or not ready status 

### Issue
https://github.com/longhorn/longhorn/issues/9016

### Test Result
https://github.com/user-attachments/assets/7779a96a-f618-452c-8e23-c9aae69adb85



### Additional documentation or context
Note. this PR need backport to v1.7.x