### PR TITLE
Remove offline replica rebuilding UI components

### DIFF
--- a/src/models/volume.js
+++ b/src/models/volume.js
@@ -76,11 +76,8 @@ export default {
     previousNamespace: '',
     recurringJobList: [],
     softAntiAffinityKey: '',
-    offlineReplicaRebuildingKey: '',
     updateReplicaSoftAntiAffinityVisible: false,
-    updateOfflineReplicaRebuildingVisible: false,
     changeVolumeModalKey: Math.random(),
-    updateOfflineReplicaRebuildingModalKey: Math.random(),
     bulkChangeVolumeModalKey: Math.random(),
     bulkExpandVolumeModalKey: Math.random(),
     createPVAndPVCModalSingleKey: Math.random(),
@@ -432,12 +429,6 @@ export default {
       yield put({ type: 'query' })
     },
     *updateReplicaSoftAntiAffinityModal({
-      payload,
-    }, { call, put }) {
-      yield payload.urls.map(url => call(execAction, url, payload.params))
-      yield put({ type: 'query' })
-    },
-    *updateOfflineReplicaRebuildingModal({
       payload,
     }, { call, put }) {
       yield payload.urls.map(url => call(execAction, url, payload.params))
@@ -1015,31 +1006,6 @@ export default {
         ...state,
         softAntiAffinityKey: '',
         updateReplicaSoftAntiAffinityVisible: false,
-      }
-    },
-    showBulkOfflineReplicaRebuildingModal(state, action) {
-      return {
-        ...state,
-        selectedRows: action?.payload?.volumes,
-        updateOfflineReplicaRebuildingVisible: true,
-        offlineReplicaRebuildingKey: action?.payload?.offlineReplicaRebuildingKey,
-        updateOfflineReplicaRebuildingModalKey: Math.random(),
-      }
-    },
-    showOfflineReplicaRebuildingModal(state, action) {
-      return {
-        ...state,
-        selected: action?.payload?.volume,
-        updateOfflineReplicaRebuildingVisible: true,
-        offlineReplicaRebuildingKey: action?.payload?.offlineReplicaRebuildingKey,
-        updateOfflineReplicaRebuildingModalKey: Math.random(),
-      }
-    },
-    hideOfflineReplicaRebuildingModal(state) {
-      return {
-        ...state,
-        offlineReplicaRebuildingKey: '',
-        updateOfflineReplicaRebuildingVisible: false,
       }
     },
     updateWs(state, action) {

--- a/src/routes/volume/CreateVolume.js
+++ b/src/routes/volume/CreateVolume.js
@@ -519,15 +519,6 @@ const modal = ({
                 <Option key={'ignored'} value={'ignored'}>Ignored (Follow the global setting)</Option>
               </Select>)}
             </FormItem>
-            { getFieldsValue().dataEngine === 'v2' && <FormItem label="Offline Replica Rebuilding" hasFeedback {...formItemLayoutForAdvanced}>
-              {getFieldDecorator('offlineReplicaRebuilding', {
-                initialValue: 'ignored',
-              })(<Select>
-                <Option key={'enabled'} value={'enabled'}>Enabled</Option>
-                <Option key={'disabled'} value={'disabled'}>Disabled</Option>
-                <Option key={'ignored'} value={'ignored'}>Ignored (Follow the global setting)</Option>
-              </Select>)}
-            </FormItem>}
             <FormItem label="Freeze Filesystem For Snapshot" hasFeedback {...formItemLayoutForAdvanced}>
               {getFieldDecorator('freezeFilesystemForSnapshot', {
                 initialValue: 'ignored',

--- a/src/routes/volume/VolumeActions.js
+++ b/src/routes/volume/VolumeActions.js
@@ -33,7 +33,6 @@ function actions({
   showUpdateReplicaSoftAntiAffinityModal,
   showUpdateReplicaZoneSoftAntiAffinityModal,
   showUpdateReplicaDiskSoftAntiAffinityModal,
-  showOfflineReplicaRebuildingModal,
   showUpdateFreezeFilesystemForSnapshotModal,
   commandKeyDown,
 }) {
@@ -156,9 +155,6 @@ function actions({
       case 'updateReplicaDiskSoftAntiAffinity':
         showUpdateReplicaDiskSoftAntiAffinityModal(record)
         break
-      case 'updateOfflineReplicaRebuilding':
-        showOfflineReplicaRebuildingModal(record)
-        break
       case 'updateFreezeFilesystemForSnapshot':
         showUpdateFreezeFilesystemForSnapshotModal(record)
         break
@@ -234,7 +230,6 @@ function actions({
     { key: 'updateSnapshotMaxCount', name: 'Update Snapshot Max Count', disabled: false },
     { key: 'updateSnapshotMaxSize', name: 'Update Snapshot Max Size', disabled: false },
     { key: 'updateReplicaDiskSoftAntiAffinity', name: 'Update Replica Disk Soft Anti Affinity', disabled: false },
-    { key: 'updateOfflineReplicaRebuilding', name: 'Update Offline Replica Rebuilding', disabled: false || selected.dataEngine !== 'v2' },
     { key: 'updateFreezeFilesystemForSnapshot', name: 'Update Freeze Filesystem For Snapshot', disabled: false },
   ]
   const availableActions = [{ key: 'backups', name: 'Backups', disabled: selected.standby || isRestoring(selected) }, { key: 'delete', name: 'Delete' }]

--- a/src/routes/volume/VolumeBulkActions.js
+++ b/src/routes/volume/VolumeBulkActions.js
@@ -32,7 +32,6 @@ function bulkActions({
   showUpdateReplicaSoftAntiAffinityModal,
   showUpdateReplicaZoneSoftAntiAffinityModal,
   showUpdateReplicaDiskSoftAntiAffinityModal,
-  showOfflineReplicaRebuildingModal,
   showUpdateBulkFreezeFilesystemForSnapshotModal,
 }) {
   const deleteWranElement = (rows) => {
@@ -138,9 +137,6 @@ function bulkActions({
       case 'updateReplicaDiskSoftAntiAffinity':
         showUpdateReplicaDiskSoftAntiAffinityModal(selectedRows)
         break
-      case 'updateOfflineReplicaRebuilding':
-        showOfflineReplicaRebuildingModal(selectedRows)
-        break
       case 'updateFreezeFilesystemForSnapshot':
         showUpdateBulkFreezeFilesystemForSnapshotModal(selectedRows)
         break
@@ -211,7 +207,6 @@ function bulkActions({
     { key: 'updateReplicaSoftAntiAffinity', name: 'Update Replica Soft Anti Affinity', disabled() { return selectedRows.length === 0 } },
     { key: 'updateReplicaZoneSoftAntiAffinity', name: 'Update Replica Zone Soft Anti Affinity', disabled() { return selectedRows.length === 0 } },
     { key: 'updateReplicaDiskSoftAntiAffinity', name: 'Update Replica Disk Soft Anti Affinity', disabled() { return selectedRows.length === 0 } },
-    { key: 'updateOfflineReplicaRebuilding', name: 'Update Offline Replica Rebuilding', disabled() { return selectedRows.length === 0 || selectedRows.some((item) => item.dataEngine !== 'v2') } },
     { key: 'trimFilesystem', name: 'Trim Filesystem', disabled() { return selectedRows.length === 0 || notAttached() } },
     { key: 'updateFreezeFilesystemForSnapshot', name: 'Update Freeze Filesystem For Snapshot', disabled() { return selectedRows.length === 0 } },
   ]

--- a/src/routes/volume/VolumeList.js
+++ b/src/routes/volume/VolumeList.js
@@ -58,7 +58,6 @@ function list({
   showUpdateReplicaSoftAntiAffinityModal,
   showUpdateReplicaZoneSoftAntiAffinityModal,
   showUpdateReplicaDiskSoftAntiAffinityModal,
-  showOfflineReplicaRebuildingModal,
   showUpdateFreezeFilesystemForSnapshotModal,
   onRowClick = f => f,
 }) {
@@ -98,7 +97,6 @@ function list({
     showUpdateReplicaSoftAntiAffinityModal,
     showUpdateReplicaZoneSoftAntiAffinityModal,
     showUpdateReplicaDiskSoftAntiAffinityModal,
-    showOfflineReplicaRebuildingModal,
     showUpdateFreezeFilesystemForSnapshotModal,
     onRowClick,
   }
@@ -185,14 +183,14 @@ function list({
                 {ha}{state}{ !record.ready ? statusForWorkload : '' }
               </div>)
           } else if (text.hyphenToHump() === 'attached' && record.robustness === 'degraded') {
-            return (<Tooltip title={record.dataEngine === 'v2' && 'Replica rebuilding will be automatically triggered when the degraded volume is detached'}>
-                <div
-                  className={classnames({ [record.robustness.toLowerCase()]: true, capitalize: true })}
-                  style={{ display: 'flex', alignItems: 'center' }}
-                >
-                  {ha}{state}{ !record.ready ? statusForWorkload : '' }
-                </div>
-              </Tooltip>)
+            return (
+              <div
+                className={classnames({ [record.robustness.toLowerCase()]: true, capitalize: true })}
+                style={{ display: 'flex', alignItems: 'center' }}
+              >
+                {ha}{state}{ !record.ready ? statusForWorkload : '' }
+              </div>
+            )
           } else if (text.hyphenToHump() === 'detached' && record.robustness === 'faulted') {
             return (<div
               className={classnames({ [record.robustness.toLowerCase()]: true, capitalize: true })}

--- a/src/routes/volume/detail/VolumeInfo.js
+++ b/src/routes/volume/detail/VolumeInfo.js
@@ -10,8 +10,6 @@ import {
   needToWaitDone,
   frontends,
   extractImageVersion,
-  getOfflineRebuiltStatus,
-  getOfflineRebuiltStatusWithoutFrontend,
 } from '../helper/index'
 import styles from './VolumeInfo.less'
 import { diskTagColor, nodeTagColor } from '../../../utils/constants'
@@ -210,20 +208,6 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
   return (
     <div>
       {errorMsg}
-      {getOfflineRebuiltStatus(selectedVolume) && <Alert
-        style={{ marginTop: 5 }}
-        message="Offline Rebuilding"
-        description="The volume is being offline rebuilding"
-        type="warning"
-        showIcon
-      />}
-      {getOfflineRebuiltStatusWithoutFrontend(selectedVolume) && <Alert
-        style={{ marginTop: 5 }}
-        message="Offline Rebuilding"
-        description={selectedVolume.offlineReplicaRebuildingRequired ? 'The volume rebuilding will be automatically triggered after detachment' : 'Offline Replica Rebuilding is disabled, the volume rebuilding will not be automatically triggered after detachment'}
-        type="warning"
-        showIcon
-      />}
       {restoreProgress}
       <div className={styles.row}>
         <span className={styles.label}> State:</span>
@@ -262,10 +246,6 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
       <div className={styles.row}>
         <span className={styles.label}> Data Engine:</span>
         {selectedVolume.dataEngine}
-      </div>
-      <div className={styles.row}>
-        <span className={styles.label}> Offline Replica Rebuilding:</span>
-        {selectedVolume.offlineReplicaRebuilding}
       </div>
       {!selectedVolume.disableFrontend ? <div className={styles.row}>
         <span className={styles.label}> Attached Node &amp; Endpoint:</span>

--- a/src/routes/volume/detail/index.js
+++ b/src/routes/volume/detail/index.js
@@ -43,7 +43,6 @@ import {
   getUpdateSnapshotDataIntegrityProps,
   getUpdateReplicaSoftAntiAffinityModalProps,
   getDetachHostModalProps,
-  getUpdateOfflineReplicaRebuildingModalProps,
   getUpdateSnapshotMaxCountModalProps,
   getUpdateSnapshotMaxSizeModalProps,
   getUpdateFreezeFilesystemForSnapshotModalProps,
@@ -149,9 +148,6 @@ function VolumeDetail({ snapshotModal, dispatch, backup, engineimage, eventlog, 
     softAntiAffinityKey,
     updateReplicaSoftAntiAffinityVisible,
     updateReplicaSoftAntiAffinityModalKey,
-    updateOfflineReplicaRebuildingVisible,
-    offlineReplicaRebuildingKey,
-    updateOfflineReplicaRebuildingModalKey,
     detachHostModalVisible,
     detachHostModalKey,
     updateSnapshotMaxCountModalVisible,
@@ -485,15 +481,6 @@ function VolumeDetail({ snapshotModal, dispatch, backup, engineimage, eventlog, 
         },
       })
     },
-    showOfflineReplicaRebuildingModal(record) {
-      dispatch({
-        type: 'volume/showOfflineReplicaRebuildingModal',
-        payload: {
-          volumes: record,
-          offlineReplicaRebuildingKey: 'updateOfflineReplicaRebuilding',
-        },
-      })
-    },
     trimFilesystem(record) {
       if (record?.actions?.trimFilesystem) {
         dispatch({
@@ -520,7 +507,6 @@ function VolumeDetail({ snapshotModal, dispatch, backup, engineimage, eventlog, 
   const engineUpgradeModalProps = getEngineUpgradeModalProps([selectedVolume], engineImages, engineUpgradePerNodeLimit, engineUpgradeModalVisible, dispatch)
   const updateReplicaAutoBalanceModalProps = getUpdateReplicaAutoBalanceModalProps([selectedVolume], updateReplicaAutoBalanceModalVisible, dispatch)
   const updateReplicaSoftAntiAffinityModalProps = getUpdateReplicaSoftAntiAffinityModalProps(selectedVolume, [], updateReplicaSoftAntiAffinityVisible, softAntiAffinityKey, dispatch)
-  const updateOfflineReplicaRebuildingModalProps = getUpdateOfflineReplicaRebuildingModalProps(selectedVolume, [], updateOfflineReplicaRebuildingVisible, offlineReplicaRebuildingKey, dispatch)
 
   const recurringJobProps = {
     dataSource: volumeRecurringJobs,
@@ -751,7 +737,6 @@ function VolumeDetail({ snapshotModal, dispatch, backup, engineimage, eventlog, 
         { updateSnapshotMaxSizeModalVisible ? <UpdateSnapshotMaxSizeModal {...updateSnapshotMaxSizeModalProps} /> : '' }
         {updateReplicaAutoBalanceModalVisible ? <UpdateReplicaAutoBalanceModal key={updateReplicaAutoBalanceModalKey} {...updateReplicaAutoBalanceModalProps} /> : ''}
         {updateReplicaSoftAntiAffinityVisible ? <CommonModal key={updateReplicaSoftAntiAffinityModalKey} {...updateReplicaSoftAntiAffinityModalProps} /> : ''}
-        {updateOfflineReplicaRebuildingVisible ? <CommonModal key={updateOfflineReplicaRebuildingModalKey} {...updateOfflineReplicaRebuildingModalProps} /> : ''}
         {updateFreezeFilesystemForSnapshotModalVisible ? <UpdateFreezeFilesystemForSnapshotModal key={updateFreezeFilesystemForSnapshotModalKey} {...updateFreezeFilesystemForSnapshotModalProps} /> : ''}
       </div>
     </div>

--- a/src/routes/volume/helper/index.js
+++ b/src/routes/volume/helper/index.js
@@ -621,71 +621,12 @@ export function getUpdateReplicaSoftAntiAffinityModalProps(volume, volumes, upda
   }
 }
 
-export function getUpdateOfflineReplicaRebuildingModalProps(volume, volumes, updateOfflineReplicaRebuildingVisible, key, dispatch) {
-  let offlineReplicaRebuildingVolumes = []
-  let fields = {}
-  switch (key) {
-    case 'updateOfflineReplicaRebuilding':
-      fields = {
-        actionKey: 'updateOfflineReplicaRebuilding',
-        key: 'offlineReplicaRebuilding',
-        name: 'Offline Replica Rebuilding',
-      }
-      offlineReplicaRebuildingVolumes = [volume]
-      break
-    case 'updateBulkOfflineReplicaRebuilding':
-      fields = {
-        actionKey: 'updateOfflineReplicaRebuilding',
-        key: 'offlineReplicaRebuilding',
-        name: 'Offline Replica Rebuilding',
-      }
-      offlineReplicaRebuildingVolumes = volumes
-      break
-    default:
-  }
-  return {
-    items: offlineReplicaRebuildingVolumes,
-    visible: updateOfflineReplicaRebuildingVisible,
-    onCancel() {
-      dispatch({
-        type: 'volume/hideOfflineReplicaRebuildingModal',
-      })
-    },
-    onOk(v, urls) {
-      dispatch({
-        type: 'volume/updateOfflineReplicaRebuildingModal',
-        payload: {
-          params: v,
-          urls,
-        },
-      })
-      dispatch({
-        type: 'volume/hideOfflineReplicaRebuildingModal',
-      })
-    },
-    options: [
-      { value: 'enabled', label: 'Enabled' },
-      { value: 'disabled', label: 'Disabled' },
-      { value: 'ignored', label: 'Ignored (Follow the global setting)' },
-    ],
-    fields,
-  }
-}
-
 export function getHealthState(state) {
   return state.toLowerCase() === 'unknown' ? 'unknown' : state.hyphenToHump()
 }
 
 export function needToWaitDone(state, replicas) {
   return state === '' || state.endsWith('ing') || replicas.findIndex(item => item.mode.toLowerCase() === 'wo') > -1
-}
-
-export function getOfflineRebuiltStatus(volume) {
-  return volume.disableFrontend && volume.dataEngine === 'v2' && volume.offlineReplicaRebuildingRequired && volume.state === 'attached'
-}
-
-export function getOfflineRebuiltStatusWithoutFrontend(volume) {
-  return !volume.disableFrontend && volume.dataEngine === 'v2' && volume.state === 'attached' && volume.robustness === 'degraded'
 }
 
 export const frontends = [

--- a/src/routes/volume/index.js
+++ b/src/routes/volume/index.js
@@ -57,7 +57,6 @@ import {
   getUpdateBulkSnapshotDataIntegrityModalProps,
   getUpdateSnapshotDataIntegrityProps,
   getUpdateReplicaSoftAntiAffinityModalProps,
-  getUpdateOfflineReplicaRebuildingModalProps,
   getDetachHostModalProps,
   getUpdateSnapshotMaxCountModalProps,
   getUpdateSnapshotMaxSizeModalProps,
@@ -201,9 +200,6 @@ class Volume extends React.Component {
       softAntiAffinityKey,
       updateReplicaSoftAntiAffinityVisible,
       updateReplicaSoftAntiAffinityModalKey,
-      updateOfflineReplicaRebuildingVisible,
-      updateOfflineReplicaRebuildingModalKey,
-      offlineReplicaRebuildingKey,
       isBulkDetach,
       updateSnapshotMaxCountModalVisible,
       updateSnapshotMaxSizeModalVisible,
@@ -605,15 +601,6 @@ class Volume extends React.Component {
           payload: {
             volume: record,
             softAntiAffinityKey: 'updateReplicaDiskSoftAntiAffinity',
-          },
-        })
-      },
-      showOfflineReplicaRebuildingModal(record) {
-        dispatch({
-          type: 'volume/showOfflineReplicaRebuildingModal',
-          payload: {
-            volume: record,
-            offlineReplicaRebuildingKey: 'updateOfflineReplicaRebuilding',
           },
         })
       },
@@ -1145,15 +1132,6 @@ class Volume extends React.Component {
           },
         })
       },
-      showOfflineReplicaRebuildingModal(record) {
-        dispatch({
-          type: 'volume/showBulkOfflineReplicaRebuildingModal',
-          payload: {
-            volumes: record,
-            offlineReplicaRebuildingKey: 'updateBulkOfflineReplicaRebuilding',
-          },
-        })
-      },
       trimBulkFilesystem(record) {
         if (record?.length > 0) {
           dispatch({
@@ -1263,7 +1241,6 @@ class Volume extends React.Component {
     }
 
     const updateReplicaSoftAntiAffinityModalProps = getUpdateReplicaSoftAntiAffinityModalProps(selected, selectedRows, updateReplicaSoftAntiAffinityVisible, softAntiAffinityKey, dispatch)
-    const updateOfflineReplicaRebuildingModalProps = getUpdateOfflineReplicaRebuildingModalProps(selected, selectedRows, updateOfflineReplicaRebuildingVisible, offlineReplicaRebuildingKey, dispatch)
     const updateReplicaCountModalProps = getUpdateReplicaCountModalProps(selected, updateReplicaCountModalVisible, dispatch)
     const updateBulKReplicaCountModalProps = getUpdateBulkReplicaCountModalProps(selectedRows, updateBulkReplicaCountModalVisible, dispatch)
     const updateDataLocalityModalProps = getUpdateDataLocalityModalProps(selected, updateDataLocalityModalVisible, defaultDataLocalityOption, dispatch)
@@ -1326,7 +1303,6 @@ class Volume extends React.Component {
         {updateSnapshotDataIntegrityModalVisible ? <UpdateSnapshotDataIntegrityModal key={updateSnapshotDataIntegrityModalKey} {...updateSnapshotDataIntegrityModalProps} /> : ''}
         {updateBulkSnapshotDataIntegrityModalVisible ? <UpdateBulkSnapshotDataIntegrityModal key={updateBulkSnapshotDataIntegrityModalKey} {...updateBulkSnapshotDataIntegrityModalProps} /> : ''}
         {updateReplicaSoftAntiAffinityVisible ? <CommonModal key={updateReplicaSoftAntiAffinityModalKey} {...updateReplicaSoftAntiAffinityModalProps} /> : ''}
-        {updateOfflineReplicaRebuildingVisible ? <CommonModal key={updateOfflineReplicaRebuildingModalKey} {...updateOfflineReplicaRebuildingModalProps} /> : ''}
         {updateFreezeFilesystemForSnapshotModalVisible ? <UpdateFreezeFilesystemForSnapshotModal key={updateFreezeFilesystemForSnapshotModalKey} {...updateFreezeFilesystemForSnapshotModalProps} /> : ''}
         {updateBulkFreezeFilesystemForSnapshotModalVisible ? <UpdateBulkFreezeFilesystemForSnapshotModal key={updateBulkFreezeFilesystemForSnapshotModalKey} {...updateBulkFreezeFilesystemForSnapshotModalProps} /> : ''}
         {me.state.createBackModalVisible ? <CreateBackupModal key={me.state.createBackModalKey} {...createBackModalProps} /> : ''}


### PR DESCRIPTION
### What this PR does / why we need it

Remove offline replica rebuilding related info and settings
- alert in volume detail page
- volume info in volume detail page
- options in create volume modal
- update modal, action button and bulk action in volume / volume detail page
- volume state tooltip

### Issue
[[IMPROVEMENT] Remove Offline Rebuilding from UI on master and v1.7.0](https://github.com/longhorn/longhorn/issues/9090)

### Test Result
Remove below UI components
<img width="871" alt="Screenshot 2024-07-29 at 11 43 33 AM" src="https://github.com/user-attachments/assets/76fd33eb-f175-4806-90ea-227a762ce2c3">
<img width="717" alt="Screenshot 2024-07-29 at 11 37 58 AM" src="https://github.com/user-attachments/assets/921eb845-7c7f-47c8-896e-b4b10690ef53">
<img width="1494" alt="Screenshot 2024-07-29 at 11 31 41 AM" src="https://github.com/user-attachments/assets/c39ca820-b476-4906-8aca-53578d03125b">
<img width="1290" alt="Screenshot 2024-07-29 at 11 31 16 AM" src="https://github.com/user-attachments/assets/f965af54-0d1e-4355-9d8e-c08f8fc67280">
<img width="521" alt="Screenshot 2024-07-29 at 11 31 03 AM" src="https://github.com/user-attachments/assets/2d94b785-7416-4f10-891f-0914dfa70b6a">
<img width="1496" alt="Screenshot 2024-07-29 at 11 30 18 AM" src="https://github.com/user-attachments/assets/cea74635-da65-415d-8cf4-8d42d6e5fced">


### Additional documentation or context
Note. this PR will backport to v1.7.x after merged.