### PR TITLE
fix: align the disk/node conditions in a vertical way

### DIFF
--- a/src/routes/host/components/EditableDiskItem.js
+++ b/src/routes/host/components/EditableDiskItem.js
@@ -42,7 +42,7 @@ function EditableDiskItem({ isNew, disk, form, onRestore, onRemove, validatePath
           <div className={styles.label}>
             Conditions
           </div>
-          <div className={styles.control} style={{ width: '690px', lineHeight: '40px', display: 'flex', padding: '0 15px' }}>
+          <div className={styles.control} style={{ lineHeight: '40px' }}>
             {disk && disk.conditions && Object.keys(disk.conditions).map((key) => {
               let title = (<div>
                 {disk.conditions[key] && disk.conditions[key].lastProbeTime && disk.conditions[key].lastProbeTime ? <div style={{ marginBottom: 5 }}>Last Probe Time: {formatDate(disk.conditions[key].lastProbeTime)}</div> : ''}

--- a/src/routes/host/components/EditableDiskItem.less
+++ b/src/routes/host/components/EditableDiskItem.less
@@ -18,9 +18,8 @@
       width: 100%;
     }
     .control {
-      padding: 5px 7px;
+      padding: 5px 14px;
       width: 100%;
     }
-  
   }
 }

--- a/src/routes/host/components/EditableDiskList.js
+++ b/src/routes/host/components/EditableDiskList.js
@@ -199,7 +199,7 @@ class EditableDiskList extends React.Component {
             <div className={styles.label}>
               Conditions
             </div>
-            <div className={styles.control} style={{ width: '690px', lineHeight: '40px', display: 'flex' }}>
+            <div className={styles.control} style={{ lineHeight: '40px' }}>
               {node && node.conditions && Object.keys(node.conditions).map((key) => {
                 let title = (<div>
                   {node.conditions[key] && node.conditions[key].lastProbeTime && node.conditions[key].lastProbeTime ? <div style={{ marginBottom: 5 }}>Last Probe Time: {formatDate(node.conditions[key].lastProbeTime)}</div> : ''}


### PR DESCRIPTION
### What this PR does / why we need it
fix: align the disk/node conditions in a vertical way.

### Issue
https://github.com/longhorn/longhorn/issues/9629

### Test Result
Add mock data in `disk.conditions` and `node.conditions` 

<img width="820" alt="image" src="https://github.com/user-attachments/assets/6d32d546-60d1-4920-b831-2f3d8449a2cd">
