### PR TITLE
feat: display reUploadedDataSize and newlyUploadedDataSize of each backup

### DIFF
--- a/src/assets/styles/antd-customize/generic.less
+++ b/src/assets/styles/antd-customize/generic.less
@@ -29,6 +29,10 @@
       text-align: center;
       background: @color-primary-light;
       color: white;
+
+      .ant-table-column-sorter .ant-table-column-sorter-inner {
+        height: unset;
+      }
     }
     .ant-table-thead > tr > th.ant-table-column-has-actions.ant-table-column-has-sorters:hover {
       background: #108eb9 !important;
@@ -56,13 +60,7 @@
     .ant-table-column-sorters {
       display: flex !important;
       justify-content: center !important;
-    }
-    .ant-table-column-sorter {
-      display : inline !important;
-      text-align: center;
-      .anticon-caret-up, .anticon-caret-down {
-        font-size: 16px !important;
-      }
+      align-items: center;
     }
   }
 

--- a/src/assets/styles/antd-customize/generic.less
+++ b/src/assets/styles/antd-customize/generic.less
@@ -42,6 +42,10 @@
       .ant-table > .ant-table-content > .ant-table-scroll > .ant-table-body {
         height: auto;
       }
+
+      .ant-tag {
+        font-size: 15px;
+      }
     }
     .ant-table-tbody > tr:hover:not(.ant-table-expanded-row) > td {
       background: #ebf2f6 !important;

--- a/src/routes/backup/BackupList.js
+++ b/src/routes/backup/BackupList.js
@@ -351,7 +351,7 @@ class List extends React.Component {
           }
           return (
             <div onClick={() => { showBackupLabels(obj) }}>
-              <Icon style={{ fontSize: '18px', color: obj ? '#108eb9' : '#cccccc', cursor: 'pointer' }} type="tags" />
+              <Icon style={{ fontSize: '18px', color: obj ? '#108ee9' : '#cccccc', cursor: 'pointer' }} type="tags" />
             </div>
           )
         },

--- a/src/routes/backup/BackupList.js
+++ b/src/routes/backup/BackupList.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Table, Modal, Icon, message, Tooltip, Progress, Input, Button } from 'antd'
+import { Table, Modal, Icon, message, Tooltip, Progress, Input, Button, Tag } from 'antd'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { DropOption } from '../../components'
 import { formatDate } from '../../utils/formatDate'
@@ -183,7 +183,14 @@ class List extends React.Component {
         key: 'backupMode',
         width: 150,
         render: (text) => {
-          return (<div>{text || 'incremental'}</div>)
+          return (
+            <div className={style.backupMode}>
+              { text === 'full'
+                ? <Tag className={style.fullTag}>{text}</Tag>
+                : <Tag>{text || 'incremental'}</Tag>
+              }
+            </div>
+          )
         },
       },
       {

--- a/src/routes/backup/BackupList.js
+++ b/src/routes/backup/BackupList.js
@@ -126,7 +126,7 @@ class List extends React.Component {
         title: 'ID',
         dataIndex: 'id',
         key: 'id',
-        width: '15%',
+        width: 100,
         sorter: (a, b) => sortTable(a, b, 'id'),
         render: (text) => {
           return (
@@ -139,7 +139,7 @@ class List extends React.Component {
         title: 'Volume',
         dataIndex: 'volumeName',
         key: 'volumeName',
-        width: '14%',
+        width: 120,
         render: (text, record) => {
           let errorMessage = record.messages && record.messages.error ? record.messages.error : ''
           return (
@@ -158,7 +158,7 @@ class List extends React.Component {
         title: 'Creation State',
         dataIndex: 'state',
         key: 'state',
-        width: 150,
+        width: 120,
         render: (text, record) => {
           if (record.state === 'InProgress') {
             return (
@@ -181,7 +181,7 @@ class List extends React.Component {
         title: 'Backup Mode',
         dataIndex: 'backupMode',
         key: 'backupMode',
-        width: 150,
+        width: 120,
         render: (text) => {
           return (
             <div className={style.backupMode}>
@@ -198,7 +198,7 @@ class List extends React.Component {
         dataIndex: 'snapshotName',
         key: 'snapshotName',
         align: 'center',
-        width: '16.72%',
+        width: 150,
         sorter: (a, b) => sortTable(a, b, 'snapshotName'),
         render: (text) => {
           return (
@@ -211,7 +211,7 @@ class List extends React.Component {
         title: 'Size',
         dataIndex: 'size',
         key: 'size',
-        width: 100,
+        width: 90,
         sorter: (a, b) => sortTable(a, b, 'size'),
         render: (text, record) => {
           return (
@@ -237,7 +237,7 @@ class List extends React.Component {
         title: 'Newly Uploaded Data Size',
         dataIndex: 'newlyUploadDataSize',
         key: 'newlyUploadDataSize',
-        width: 180,
+        width: 150,
         sorter: (a, b) => sortTable(a, b, 'newlyUploadDataSize'),
         render: (text, record) => {
           return (
@@ -247,10 +247,10 @@ class List extends React.Component {
           )
         },
       }, {
-        title: <div>PV/PVC</div>,
+        title: 'PV/PVC',
         dataIndex: 'labels',
         key: 'KubernetesStatus',
-        width: '7.63%',
+        width: 90,
         render: (record) => {
           let storageObj = {}
 
@@ -290,7 +290,7 @@ class List extends React.Component {
         title: 'Workload/Pod',
         dataIndex: 'labels',
         key: 'WorkloadNameAndPodName',
-        width: '12.5%',
+        width: 150,
         render: (record) => {
           let storageObj = {}
 
@@ -330,7 +330,7 @@ class List extends React.Component {
         title: 'Snapshot Created',
         dataIndex: 'snapshotCreated',
         key: 'snapshotCreated',
-        width: 220,
+        width: 150,
         sorter: (a, b) => sortTable(a, b, 'snapshotCreated'),
         render: (text) => {
           return (

--- a/src/routes/backup/BackupList.js
+++ b/src/routes/backup/BackupList.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Table, Modal, Icon, message, Tooltip, Progress, Input, Button, Tag } from 'antd'
+import { Table, Modal, Icon, message, Tooltip, Progress, Input, Button } from 'antd'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { DropOption } from '../../components'
 import { formatDate } from '../../utils/formatDate'
@@ -185,11 +185,8 @@ class List extends React.Component {
         sorter: (a, b) => sortTable(a, b, 'backupMode'),
         render: (text) => {
           return (
-            <div className={style.backupMode}>
-              { text === 'full'
-                ? <Tag className={style.fullTag}>{text}</Tag>
-                : <Tag>{text || 'incremental'}</Tag>
-              }
+            <div>
+              {text || 'incremental'}
             </div>
           )
         },

--- a/src/routes/backup/BackupList.js
+++ b/src/routes/backup/BackupList.js
@@ -182,6 +182,7 @@ class List extends React.Component {
         dataIndex: 'backupMode',
         key: 'backupMode',
         width: 120,
+        sorter: (a, b) => sortTable(a, b, 'backupMode'),
         render: (text) => {
           return (
             <div className={style.backupMode}>

--- a/src/routes/backup/BackupList.js
+++ b/src/routes/backup/BackupList.js
@@ -214,6 +214,32 @@ class List extends React.Component {
           )
         },
       }, {
+        title: 'Re-Uploaded Data Size',
+        dataIndex: 'reUploadedDataSize',
+        key: 'reUploadedDataSize',
+        width: 150,
+        sorter: (a, b) => sortTable(a, b, 'reUploadedDataSize'),
+        render: (text, record) => {
+          return (
+            <div>
+              {record.state === 'Completed' && formatMib(text)}
+            </div>
+          )
+        },
+      }, {
+        title: 'Newly Uploaded Data Size',
+        dataIndex: 'newlyUploadDataSize',
+        key: 'newlyUploadDataSize',
+        width: 180,
+        sorter: (a, b) => sortTable(a, b, 'newlyUploadDataSize'),
+        render: (text, record) => {
+          return (
+            <div>
+              {record.state === 'Completed' && formatMib(text)}
+            </div>
+          )
+        },
+      }, {
         title: <div>PV/PVC</div>,
         dataIndex: 'labels',
         key: 'KubernetesStatus',

--- a/src/routes/backup/backupList.less
+++ b/src/routes/backup/backupList.less
@@ -25,7 +25,6 @@
     }
 
     .fullTag {
-        color: #1890ff;
         background: #e6f7ff;
     }
 }

--- a/src/routes/backup/backupList.less
+++ b/src/routes/backup/backupList.less
@@ -9,10 +9,23 @@
         top: -20px;
         left: 50%;
         text-align: center;
-        transform: translateX(-50%); 
+        transform: translateX(-50%);
         height: 24px;
         line-height: 24px;
         overflow: hidden;
         text-overflow:ellipsis;
+    }
+}
+
+.backupMode {
+    :global {
+        .ant-tag {
+            border: 0;
+        }
+    }
+
+    .fullTag {
+        color: #1890ff;
+        background: #e6f7ff;
     }
 }

--- a/src/routes/backup/backupList.less
+++ b/src/routes/backup/backupList.less
@@ -16,15 +16,3 @@
         text-overflow:ellipsis;
     }
 }
-
-.backupMode {
-    :global {
-        .ant-tag {
-            border: 0;
-        }
-    }
-
-    .fullTag {
-        background: #e6f7ff;
-    }
-}


### PR DESCRIPTION
### What this PR does / why we need it
- [x] Display `Re-Uploaded Data Size` and `Newly Uploaded Data Size` of each backup
- [ ] Highlight `full` backups by color tag
- [x] Enable sorting for backup mode

### Issue
[[UI][IMPROVEMENT] Display ReUploadedDataSize and NewlyUploadedDataSize of each backup on Volume page](https://github.com/longhorn/longhorn/issues/8975)

### Test Result

- The table should display `Re-Uploaded Data Size` and `Newly Uploaded Data Size`
- When creating a full backup, it will be highlighted with a blue tag

![Screenshot 2024-11-26 at 11 42 31 AM (2)](https://github.com/user-attachments/assets/25ff4c6d-4e16-4414-9ab9-8593a08b0fc5)

- Click the sort icon to sort backup modes

![Screenshot 2024-11-27 at 8 05 49 AM (2)](https://github.com/user-attachments/assets/c8ab2959-92e7-439b-ac28-2280d48e5ed9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced table structure in the Backup List with new columns for 'Re-Uploaded Data Size' and 'Newly Uploaded Data Size'.
	- Improved visual representation of the 'Backup Mode' column using sorter functionality for better differentiation.
- **Style**
	- Updated styles for Ant Design components, enhancing hover effects and alignment for tables and cards.
	- Introduced new styling for backup mode elements to improve appearance and usability.
- **Bug Fixes**
	- Minor adjustments to rendering functions for better data presentation without altering core functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->