### PR TITLE
feat: expose Engine Image CLIAPIVersion and ControllerAPIVersion 

### DIFF
--- a/src/routes/engineimage/detail/EngineImageInfo.js
+++ b/src/routes/engineimage/detail/EngineImageInfo.js
@@ -34,6 +34,14 @@ function EngineImageInfo({ selectedEngineImage }) {
         <span>{selectedEngineImage.default ? 'True' : 'False'}</span>
       </div>
       <div className={styles.row}>
+        <span className={styles.label}>CLIAPIVersion:</span>
+        <span>{selectedEngineImage.cliAPIVersion}</span>
+      </div>
+      <div className={styles.row}>
+        <span className={styles.label}>ControllerAPIVersion:</span>
+        <span>{selectedEngineImage.controllerAPIVersion}</span>
+      </div>
+      <div className={styles.row}>
         <span className={styles.label}>Image:</span>
         <span>{selectedEngineImage.image}</span>
       </div>


### PR DESCRIPTION
### What this PR does / why we need it
- [x] Display `CLIAPIVersion` and `ControllerAPIVersion` on Engine Image Detail page

### Issue
[[IMPROVEMENT] Expose EngineImage CLIAPIVersion and ControllerAPIVersion ](https://github.com/longhorn/longhorn/issues/6531)

### Test Result
The page should display `CLIAPIVersion` and `ControllerAPIVersion`
![Screenshot 2024-12-02 at 4 40 08 PM (2)](https://github.com/user-attachments/assets/52f5cbb1-c597-4edd-866b-fa88ea2edf0e)

### Additional documentation or context
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `EngineImageInfo` component to display `CLIAPIVersion` and `ControllerAPIVersion` for improved user visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->