### PR TITLE
fix: remove unneeded isEdit condition for retain field

### DIFF
--- a/src/routes/volume/detail/CreateRecurringJob.js
+++ b/src/routes/volume/detail/CreateRecurringJob.js
@@ -353,7 +353,7 @@ const modal = ({
                       required: true,
                     },
                   ],
-                })(<InputNumber disabled={noRetain(getFieldValue('task')) || isEdit} style={{ width: '80%' }} min={0} />)}
+                })(<InputNumber disabled={noRetain(getFieldValue('task'))} style={{ width: '80%' }} min={0} />)}
               </FormItem>
               <FormItem label="Concurrency" hasFeedback {...formItemLayout}>
                 {getFieldDecorator('concurrency', {


### PR DESCRIPTION
### What this PR does / why we need it

fix: remove unneeded isEdit condition for retain field when editing recurring job.

The isEdit in src/routes/recurringJob/CreateRecurringJob.js is already removed in https://github.com/longhorn/longhorn-ui/commit/b749859d3157e4e2be3e5e9300ba0dd488862b4b

### Issue
https://github.com/longhorn/longhorn/issues/8810


### Test Result
Only `snapshot-cleanup` or `filesystem-trim` tasks will disable retain field. Other tasks is editable.

<img width="1472" alt="Screenshot 2024-12-04 at 2 18 23 PM" src="https://github.com/user-attachments/assets/c005c2ae-7492-4703-8e28-5c149c1bf6bf">
<img width="1492" alt="Screenshot 2024-12-04 at 2 18 03 PM" src="https://github.com/user-attachments/assets/a072a08d-cc6c-45cd-8bc6-42636de6b2a4">


### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced form handling for creating recurring jobs with improved logic for the `retain` input field.
	- Added functionality for managing groups and labels within the modal.

- **Bug Fixes**
	- Ensured the `groups` field initializes as an empty array if null, improving data robustness.
	- Refined label processing to ensure correct object construction from filtered labels.

- **Documentation**
	- Updated PropTypes for clarity in the modal component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->