### PR TITLE
feat: collect and display disk space usage for the backing images

### DIFF
--- a/src/routes/host/HostList.js
+++ b/src/routes/host/HostList.js
@@ -307,6 +307,7 @@ class List extends React.Component {
                     percent={percent}
                     successPercent={backingImagePercent}
                     showInfo={false}
+                    className={styles.progress}
                   />
                 </Tooltip>
               </div>

--- a/src/routes/host/HostList.js
+++ b/src/routes/host/HostList.js
@@ -314,23 +314,27 @@ class List extends React.Component {
           const backingImageAllocated = computeBackingImageAllocated(record)
           const replicaAllocated = computeReplicaAllocated(record)
           const percent = computeUsagePercentage(allocated, total)
-          const replicaPercent = computeUsagePercentage(replicaAllocated, total)
+          const backingImagePercent = computeUsagePercentage(backingImageAllocated, total)
           const status = getStorageProgressStatus(minimalSchedulingQuotaWarning, percent)
+
+          const renderTooltipContent = () => (
+            <div className={styles.allocatedTooltip}>
+              <span>Replica Size: {byteToGi(replicaAllocated)} Gi</span>
+              <span>Backing Image Size: {byteToGi(backingImageAllocated)} Gi</span>
+              <span>Total Usage: {percent}%</span>
+            </div>
+          )
+          const tooltipContent = renderTooltipContent()
+
           return (
             <div>
               <div>
-                <Tooltip title={() => (
-                  <div className={styles.allocatedTooltip}>
-                    <span>Replica Size: {byteToGi(replicaAllocated)} Gi</span>
-                    <span>Backing Image Size: {byteToGi(backingImageAllocated)} Gi</span>
-                    <span>Total Usage: {percent}%</span>
-                  </div>
-                )}>
+                <Tooltip title={tooltipContent}>
                   <Progress
                     strokeWidth={14}
                     status={status}
                     percent={percent}
-                    successPercent={replicaPercent}
+                    successPercent={backingImagePercent}
                     showInfo={false}
                   />
                 </Tooltip>

--- a/src/routes/host/HostList.js
+++ b/src/routes/host/HostList.js
@@ -8,7 +8,19 @@ import DiskList from './DiskList'
 import HostActions from './HostActions'
 import InstanceManagerComponent from './components/InstanceManagerComponent'
 import { nodeStatusColorMap } from '../../utils/status'
-import { byteToGi, getStorageProgressStatus } from './helper/index'
+import {
+  byteToGi,
+  getStorageProgressStatus,
+  computeTotalAllocated,
+  computeAllocated,
+  computeBackingImageAllocated,
+  computeReplicaAllocated,
+  computeUsagePercentage,
+  computeTotalUsed,
+  computeUsed,
+  computeSize,
+  computeReserved
+} from './helper/index'
 import { formatMib } from '../../utils/formatter'
 import { pagination } from '../../utils/page'
 import { ModalBlur } from '../../components'
@@ -195,47 +207,6 @@ class List extends React.Component {
       deleteHost,
     }
 
-    const computeTotalAllocated = (record) => {
-      const max = Object.values(record.disks).reduce((total, item) => total + item.storageMaximum, 0)
-      const reserved = Object.values(record.disks).reduce((total, item) => total + item.storageReserved, 0)
-      return ((max - reserved) * storageOverProvisioningPercentage) / 100
-    }
-    const computeAllocated = (record) => {
-      return Object.values(record.disks).reduce((total, item) => total + item.storageScheduled, 0)
-    }
-    const computeTotalSize = (record, property) => {
-      return Object.keys(record.disks).reduce((totalSize, key) => {
-        const disk = record.disks[key]
-        const propertyData = disk[property]
-
-        if (propertyData) {
-          totalSize += Object.values(propertyData).reduce((acc, size) => acc + size, 0)
-        }
-
-        return totalSize
-      }, 0)
-    }
-    const computeBackingImageAllocated = (record) => {
-      return computeTotalSize(record, 'scheduledBackingImage')
-    }
-    const computeReplicaAllocated = (record) => {
-      return computeTotalSize(record, 'scheduledReplica')
-    }
-    const computeUsagePercentage = (allocated, total) => {
-      return total > 0 ? Math.round((allocated / total) * 100) : 0
-    }
-    const coumputeTotalUsed = (record) => {
-      return Object.values(record.disks).reduce((total, item) => total + item.storageMaximum, 0)
-    }
-    const computeUsed = (record) => {
-      return Object.values(record.disks).reduce((total, item) => total + (item.storageMaximum - item.storageAvailable), 0)
-    }
-    const computeSize = (record) => {
-      return Object.values(record.disks).reduce((total, item) => total + (item.storageMaximum - item.storageReserved), 0)
-    }
-    const computeReserved = (record) => {
-      return Object.values(record.disks).reduce((total, item) => total + item.storageReserved, 0)
-    }
     const columns = [
       {
         title: <span style={{ display: 'inline-block', padding: '0 0 0 30px' }}>Status</span>,
@@ -310,7 +281,7 @@ class List extends React.Component {
         sorter: (a, b) => computeAllocated(a) - computeAllocated(b),
         render: (text, record) => {
           const allocated = computeAllocated(record)
-          const total = computeTotalAllocated(record)
+          const total = computeTotalAllocated(record, storageOverProvisioningPercentage)
           const backingImageAllocated = computeBackingImageAllocated(record)
           const replicaAllocated = computeReplicaAllocated(record)
           const percent = computeUsagePercentage(allocated, total)
@@ -353,7 +324,7 @@ class List extends React.Component {
         sorter: (a, b) => computeUsed(a) - computeUsed(b),
         render: (text, record) => {
           const used = computeUsed(record)
-          const total = coumputeTotalUsed(record)
+          const total = computeTotalUsed(record)
           const p = computeUsagePercentage(used, total)
 
           return (

--- a/src/routes/host/HostList.less
+++ b/src/routes/host/HostList.less
@@ -2,7 +2,7 @@
   color: #27ae60;
 }
 .status, .name, .allocated, .replicas, .used, .size {
-  text-align: center !important; 
+  text-align: center !important;
 }
 .allowScheduling {
   text-align: right !important;
@@ -20,4 +20,8 @@ a {
   .ant-progress-status-success .ant-progress-bg {
     background-color: #27AE5F !important;
   }
+}
+.allocatedTooltip {
+  display: flex;
+  flex-direction: column;
 }

--- a/src/routes/host/HostList.less
+++ b/src/routes/host/HostList.less
@@ -25,3 +25,11 @@ a {
   display: flex;
   flex-direction: column;
 }
+
+.progress {
+  :global {
+    .ant-progress-success-bg {
+      background: #f1c40f
+    }
+  }
+}

--- a/src/routes/host/HostList.less
+++ b/src/routes/host/HostList.less
@@ -29,7 +29,7 @@ a {
 .progress {
   :global {
     .ant-progress-success-bg {
-      background: #f1c40f
+      background: darken(#27AE5F, 10%)
     }
   }
 }

--- a/src/routes/host/HostList.less
+++ b/src/routes/host/HostList.less
@@ -29,7 +29,7 @@ a {
 .progress {
   :global {
     .ant-progress-success-bg {
-      background: darken(#27AE5F, 10%)
+      background: #219653; // darken(#27AE5F, 10%)
     }
   }
 }

--- a/src/routes/host/helper/index.js
+++ b/src/routes/host/helper/index.js
@@ -25,3 +25,54 @@ export function getStorageProgressStatus(minimalSchedulingQuotaWarning, percent)
   }
   return 'success'
 }
+
+export const computeTotalAllocated = (record, storageOverProvisioningPercentage) => {
+  const max = Object.values(record.disks).reduce((total, item) => total + item.storageMaximum, 0)
+  const reserved = Object.values(record.disks).reduce((total, item) => total + item.storageReserved, 0)
+  return ((max - reserved) * storageOverProvisioningPercentage) / 100
+}
+
+export const computeAllocated = (record) => {
+  return Object.values(record.disks).reduce((total, item) => total + item.storageScheduled, 0)
+}
+
+export const computeTotalSize = (record, property) => {
+  if (!record?.disks) return 0
+  return Object.keys(record.disks).reduce((totalSize, key) => {
+    const disk = record.disks[key]
+
+    if (!disk) return totalSize
+    if (disk[property]) {
+      totalSize += Object.values(disk[property]).reduce((acc, size) => acc + size, 0)
+    }
+    return totalSize
+  }, 0)
+}
+
+export const computeBackingImageAllocated = (record) => {
+  return computeTotalSize(record, 'scheduledBackingImage')
+}
+
+export const computeReplicaAllocated = (record) => {
+  return computeTotalSize(record, 'scheduledReplica')
+}
+
+export const computeUsagePercentage = (allocated, total) => {
+  return total > 0 ? Math.round((allocated / total) * 100) : 0
+}
+
+export const computeTotalUsed = (record) => {
+  return Object.values(record.disks).reduce((total, item) => total + item.storageMaximum, 0)
+}
+
+export const computeUsed = (record) => {
+  return Object.values(record.disks).reduce((total, item) => total + (item.storageMaximum - item.storageAvailable), 0)
+}
+
+export const computeSize = (record) => {
+  return Object.values(record.disks).reduce((total, item) => total + (item.storageMaximum - item.storageReserved), 0)
+}
+
+export const computeReserved = (record) => {
+  return Object.values(record.disks).reduce((total, item) => total + item.storageReserved, 0)
+}


### PR DESCRIPTION
### What this PR does / why we need it
- [x] show segment in allocated bar
- [x] show the` Backing Image size sum` and `Replica size sum` in tooltip

### Issue
[[UI IMPROVEMENT] Collect and display disk space usage for the backing images](https://github.com/longhorn/longhorn/issues/9325)

### Test Result
![Screenshot 2024-12-09 at 9 50 16 AM (2)](https://github.com/user-attachments/assets/3a8c07b8-3d81-41ab-b9e1-664a179e0418)

### Additional documentation or context
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced disk usage metrics with detailed calculations for allocated and used storage in the Host List.
	- Tooltips for 'Allocated' and 'Used' columns now provide clearer, more detailed information.

- **Style**
	- Introduced new CSS classes for improved tooltip layout and progress bar styling in the Host List.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->