### PR TITLE
feat: improve the volume size information on UI

### DIFF
--- a/src/routes/volume/detail/VolumeInfo.js
+++ b/src/routes/volume/detail/VolumeInfo.js
@@ -164,8 +164,6 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
       </div>)
     } else if (isExpanding) {
       message = `The volume is in expansion progress from size ${formatMib(currentSize)} to size ${formatMib(expectedSize)}`
-    } else {
-      message = 'Maximum available space for the volume.'
     }
 
     return (
@@ -206,6 +204,12 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
     }
     return text
   }
+
+  const renderLabelTooltip = (title) => (
+    <Tooltip overlayClassName={styles.labelTooltip} title={title}>
+      <Icon type="info-circle" />
+    </Tooltip>
+  )
 
   return (
     <div>
@@ -257,14 +261,20 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
         {selectedVolume.controllers ? selectedVolume.controllers.filter(item => item.hostId !== '').map(item => <div style={{ fontFamily: 'monospace', margin: '2px 0px' }} key={item.hostId}>{item.hostId}</div>) : ''}
       </div>}
       <div className={styles.row}>
-        <span className={styles.label}> Size:</span>
+        <span className={styles.label}>
+          <span>Size</span>
+          {renderLabelTooltip('Space capacity of a volume.')}
+          <span>:</span>
+        </span>
         {volumeSizeEle()}
       </div>
       <div className={styles.row}>
-        <span className={styles.label}>Actual Size:</span>
-        <Tooltip title={'Space used by each replica, including data and snapshots.'}>
-          {state ? formatMib(computeActualSize) : 'Unknown'}
-        </Tooltip>
+        <span className={styles.label}>
+          <span>Actual Size</span>
+          {renderLabelTooltip('Actual storage space used for the volume, including volume-head and snapshots, which may exceed the size.')}
+          <span>:</span>
+        </span>
+        {state ? formatMib(computeActualSize) : 'Unknown'}
       </div>
       <div className={styles.row}>
         <span className={styles.label}>Data Locality:</span>
@@ -285,9 +295,11 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
         </div>
       </div> : ''}
       <div className={styles.row}>
-        <Tooltip title={'Provides the binary to start and communicate with the volume engine/replicas.'}>
-          <span className={styles.label}> Engine Image:</span>
-        </Tooltip>
+        <span className={styles.label}>
+          <span>Engine Image</span>
+          {renderLabelTooltip('Provides the binary to start and communicate with the volume engine/replicas.')}
+          <span>:</span>
+        </span>
         {selectedVolume.image}
       </div>
       <div className={styles.row}>
@@ -331,9 +343,11 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
         {formatMib(selectedVolume.snapshotMaxSize)}
       </div>
       <div className={styles.row}>
-        <Tooltip title={'Manages the engine/replica instances’ life cycle on the node.'}>
-          <span className={styles.label}> Instance Manager:</span>
-        </Tooltip>
+        <span className={styles.label}>
+          <span>Instance Manager</span>
+          {renderLabelTooltip('Manages the engine/replica instances’ life cycle on the node.')}
+          <span>:</span>
+        </span>
         {selectedVolume.controllers ? selectedVolume.controllers.filter(item => item.instanceManagerName !== '').map(item => <div key={item.hostId} style={{ fontFamily: 'monospace', margin: '2px 0px' }}> <span style={{ backgroundColor: '#f2f4f5' }}> {item.instanceManagerName} </span></div>) : ''}
       </div>
       <div className={styles.row}>

--- a/src/routes/volume/detail/VolumeInfo.js
+++ b/src/routes/volume/detail/VolumeInfo.js
@@ -164,6 +164,8 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
       </div>)
     } else if (isExpanding) {
       message = `The volume is in expansion progress from size ${formatMib(currentSize)} to size ${formatMib(expectedSize)}`
+    } else {
+      message = 'Maximum available space for the volume.'
     }
 
     return (
@@ -256,12 +258,13 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
       </div>}
       <div className={styles.row}>
         <span className={styles.label}> Size:</span>
-        {/* {formatMib(selectedVolume.size)} */}
         {volumeSizeEle()}
       </div>
       <div className={styles.row}>
         <span className={styles.label}>Actual Size:</span>
-        {state ? formatMib(computeActualSize) : 'Unknown'}
+        <Tooltip title={'Space used by each replica, including data and snapshots.'}>
+          {state ? formatMib(computeActualSize) : 'Unknown'}
+        </Tooltip>
       </div>
       <div className={styles.row}>
         <span className={styles.label}>Data Locality:</span>

--- a/src/routes/volume/detail/VolumeInfo.js
+++ b/src/routes/volume/detail/VolumeInfo.js
@@ -263,7 +263,7 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
       <div className={styles.row}>
         <span className={styles.label}>
           <span>Size</span>
-          {renderLabelTooltip('Space capacity of a volume.')}
+          {renderLabelTooltip('Amount of space available to the volume when in use. This is the size that you specified when you created the volume.')}
           <span>:</span>
         </span>
         {volumeSizeEle()}
@@ -271,7 +271,7 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
       <div className={styles.row}>
         <span className={styles.label}>
           <span>Actual Size</span>
-          {renderLabelTooltip('Actual storage space used for the volume, including volume-head and snapshots, which may exceed the size.')}
+          {renderLabelTooltip('Amount of space used by the volume head and snapshots. This can exceed the value of the "Size" field.')}
           <span>:</span>
         </span>
         {state ? formatMib(computeActualSize) : 'Unknown'}

--- a/src/routes/volume/detail/VolumeInfo.less
+++ b/src/routes/volume/detail/VolumeInfo.less
@@ -1,6 +1,13 @@
 .label {
   color: lightslategray;
   margin-right: 10px;
+
+  :global {
+    .anticon-info-circle {
+      margin: 0 5px;
+      cursor: pointer;
+    }
+  }
 }
 
 .row {
@@ -15,4 +22,8 @@
   width: 100%;
   height: 100%;
   left: -9px;
+}
+
+.labelTooltip {
+  max-width: 250px;
 }


### PR DESCRIPTION
### What this PR does / why we need it
Backport of PR for v1.7.x. 
The original PR can be found at: https://github.com/longhorn/longhorn-ui/pull/825.
### Issue
[[UI][IMPROVEMENT] Improve the volume size information on UI #8843
](https://github.com/longhorn/longhorn/issues/8843)

### Test Result
![Screenshot 2024-12-12 at 2 35 03 PM (2)](https://github.com/user-attachments/assets/1702b9b9-c8ce-47a9-aa00-80033a05dbe0)

### Additional documentation or context
N/A
