### PR TITLE
feat: attach table search keyword to URL on Backup page

### DIFF
--- a/src/models/backingImage.js
+++ b/src/models/backingImage.js
@@ -45,8 +45,6 @@ export default {
     selectedDiskStateMapRowKeys: [],
     biSearchField: '',
     biSearchValue: '',
-    bbiSearchField: '',
-    bbiSearchValue: '',
     biSocketStatus: 'closed',
     bbiSocketStatus: 'closed',
   },

--- a/src/models/backup.js
+++ b/src/models/backup.js
@@ -327,6 +327,15 @@ export default {
         let wsBackup = yield select(state => state.backup.wsBackup)
         if (wsBackup) wsBackup.close(1000)
       }
+
+      if (payload.type === 'backupbackingimages') {
+        const wsBbi = yield select(state => state.backingImage.wsBbi)
+        if (wsBbi) {
+          wsBbi.open()
+        } else {
+          wsChanges(payload.dispatch, payload.type, '1s', payload.ns)
+        }
+      }
     },
     *stopWS({
       // eslint-disable-next-line no-unused-vars

--- a/src/routes/backup/index.js
+++ b/src/routes/backup/index.js
@@ -3,28 +3,12 @@ import PropTypes from 'prop-types'
 import { Tabs } from 'antd'
 import { connect } from 'dva'
 import { routerRedux } from 'dva/router'
-import queryString from 'query-string'
 import BackupVolume from './BackupVolume'
 import BackupBackingImage from '../backingImage/BackupBackingImage'
 import styles from './index.less'
 
 function Backup({ dispatch, location }) {
   const { pathname, hash, search } = location
-
-  const handleBackupBackingImageSearch = (filter = {}) => {
-    const { field, value } = filter
-
-    dispatch(routerRedux.push({
-      pathname,
-      hash,
-      search: queryString.stringify({
-        ...queryString.parse(search),
-        field,
-        value
-      })
-    }))
-  }
-
   const tabs = [
     {
       key: 'volume',
@@ -35,10 +19,7 @@ function Backup({ dispatch, location }) {
       key: 'backing-image',
       label: 'Backing Image',
       content:
-        <BackupBackingImage
-          location={location}
-          onSearch={handleBackupBackingImageSearch}
-        />
+        <BackupBackingImage persistFilterInURL location={location} />
     }
   ]
   const defaultKey = tabs[0].key

--- a/src/routes/backup/index.js
+++ b/src/routes/backup/index.js
@@ -3,12 +3,28 @@ import PropTypes from 'prop-types'
 import { Tabs } from 'antd'
 import { connect } from 'dva'
 import { routerRedux } from 'dva/router'
+import queryString from 'query-string'
 import BackupVolume from './BackupVolume'
 import BackupBackingImage from '../backingImage/BackupBackingImage'
 import styles from './index.less'
 
 function Backup({ dispatch, location }) {
   const { pathname, hash, search } = location
+
+  const handleBackupBackingImageSearch = (filter = {}) => {
+    const { field, value } = filter
+
+    dispatch(routerRedux.push({
+      pathname,
+      hash,
+      search: queryString.stringify({
+        ...queryString.parse(search),
+        field,
+        value
+      })
+    }))
+  }
+
   const tabs = [
     {
       key: 'volume',
@@ -19,10 +35,14 @@ function Backup({ dispatch, location }) {
       key: 'backing-image',
       label: 'Backing Image',
       content:
-        <BackupBackingImage location={location} />
+        <BackupBackingImage
+          location={location}
+          onSearch={handleBackupBackingImageSearch}
+        />
     }
   ]
   const defaultKey = tabs[0].key
+  const activeTab = hash ? hash.replace('#', '') : defaultKey
 
   useEffect(() => {
     if (!hash) {
@@ -33,8 +53,6 @@ function Backup({ dispatch, location }) {
   const handleTabChange = (key) => {
     dispatch(routerRedux.replace({ pathname, hash: key }))
   }
-
-  const activeTab = hash ? hash.replace('#', '') : defaultKey
 
   return (
     <Tabs

--- a/src/routes/backup/index.js
+++ b/src/routes/backup/index.js
@@ -8,7 +8,7 @@ import BackupBackingImage from '../backingImage/BackupBackingImage'
 import styles from './index.less'
 
 function Backup({ dispatch, location }) {
-  const { pathname, hash } = location
+  const { pathname, hash, search } = location
   const tabs = [
     {
       key: 'volume',
@@ -26,7 +26,7 @@ function Backup({ dispatch, location }) {
 
   useEffect(() => {
     if (!hash) {
-      dispatch(routerRedux.replace({ pathname, hash: defaultKey }))
+      dispatch(routerRedux.replace({ pathname, hash: defaultKey, search }))
     }
   }, [hash, pathname, dispatch])
 

--- a/src/utils/dataDependency.js
+++ b/src/utils/dataDependency.js
@@ -97,6 +97,9 @@ const dependency = {
       ns: 'backingImage',
       key: 'backingimages',
     }, {
+      ns: 'backingImage',
+      key: 'backupbackingimages',
+    }, {
       ns: 'backup',
       key: 'backupvolumes',
     }, {


### PR DESCRIPTION
### What this PR does / why we need it
- [x] Appends the table search keyword to the URL as a query parameter
- [x] Enables direct access to filtered table results via URLs
- [x] Enables backup backing image web socket on Backup page

### Issue
[[IMPROVEMENT][UI] Attach table search keyword to URL on Backup pages #9974](https://github.com/longhorn/longhorn/issues/9974)

### Test Result
Verified that the search keyword is appended to the URL and the table reflects the filter from URL query parameters on the `Backup` pages.
http://localhost:8080/#/backup?field=name&value=pvc#volume
![Screenshot 2024-12-16 at 12 35 22 PM (2)](https://github.com/user-attachments/assets/3890feed-e7e6-4b55-b32a-2d93d56c6395)

http://localhost:8080/#/backup?field=name&value=test#backing-image
![Screenshot 2024-12-16 at 12 35 14 PM (2)](https://github.com/user-attachments/assets/7ffc6c72-e508-4ff2-a874-2e8c04278712)

Verified that the search keyword is **NOT** appended to the URL on the `Backing image` pages.
![Screenshot 2024-12-16 at 12 41 02 PM (2)](https://github.com/user-attachments/assets/68962b1c-4400-4186-ab5a-505687dcbb96)

Verified ws functionality: changes to backup backing images on the `Backing Image` page are automatically reflected on the `Backup` page.
![Screenshot 2024-12-16 at 12 43 37 PM (2)](https://github.com/user-attachments/assets/b428d754-7229-4798-809b-c27f2ad80d3a)

### Additional documentation or context
Test with `LONGHORN_MANAGER_IP=http://178.128.17.154:30001/ npm run dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added URL state management for search filters in the `BackupBackingImage` component.
	- Enhanced WebSocket management for real-time updates related to backup backing images.

- **Bug Fixes**
	- Improved error handling for upload failures and missing URLs in the backing image restoration process.

- **Chores**
	- Simplified state management by removing unused properties in the backing image model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->