### PR TITLE
feat: support V2 Backing Image in UI

### DIFF
--- a/src/routes/backingImage/BackingImageActions.js
+++ b/src/routes/backingImage/BackingImageActions.js
@@ -52,10 +52,28 @@ function actions({
   }
 
   const availableActions = [
-    { key: 'updateMinCopies', name: 'Update Minimum Copies Count', disabled: disableAction, tooltip: disableAction ? 'Missing disk with ready state' : '' },
-    { key: 'backup', name: ' Back Up', disabled: disableAction || backupTargetAvailable === false, tooltip: getBackupActionTooltip() },
-    { key: 'download', name: 'Download', disabled: disableAction, tooltip: disableAction ? 'Missing disk with ready state' : '' },
-    { key: 'delete', name: 'Delete' },
+    {
+      key: 'updateMinCopies',
+      name: 'Update Minimum Copies Count',
+      disabled: disableAction,
+      tooltip: disableAction ? 'Missing disk with ready state' : ''
+    },
+    {
+      key: 'backup',
+      name: ' Back Up',
+      disabled: disableAction || backupTargetAvailable === false,
+      tooltip: getBackupActionTooltip()
+    },
+    {
+      key: 'download',
+      name: 'Download',
+      disabled: disableAction || selected.dataEngine === 'v2',
+      tooltip: disableAction ? 'Missing disk with ready state' : ''
+    },
+    {
+      key: 'delete',
+      name: 'Delete'
+    },
   ]
 
   return (

--- a/src/routes/backingImage/BackingImageBulkActions.js
+++ b/src/routes/backingImage/BackingImageBulkActions.js
@@ -90,9 +90,29 @@ function bulkActions({ selectedRows, backupProps, deleteBackingImages, downloadS
   }
 
   const allActions = [
-    { key: 'delete', name: 'Delete', disabled() { return selectedRows.length === 0 } },
-    { key: 'download', name: 'Download', disabled() { return (selectedRows.length === 0 || selectedRows.every(row => !hasReadyBackingDisk(row))) } },
-    { key: 'backup', name: 'Back Up', disabled() { return selectedRows.length === 0 || backupTargetAvailable === false || selectedRows.every(row => !hasReadyBackingDisk(row)) } },
+    {
+      key: 'delete',
+      name: 'Delete',
+      disabled() { return selectedRows.length === 0 }
+    },
+    {
+      key: 'download',
+      name: 'Download',
+      disabled() {
+        return selectedRows.length === 0
+          || selectedRows.every(row => !hasReadyBackingDisk(row))
+          || selectedRows.some(row => row.dataEngine === 'v2')
+      }
+    },
+    {
+      key: 'backup',
+      name: 'Back Up',
+      disabled() {
+        return selectedRows.length === 0
+          || backupTargetAvailable === false
+          || selectedRows.every(row => !hasReadyBackingDisk(row))
+      }
+    },
   ]
 
   return (

--- a/src/routes/backingImage/BackingImageList.js
+++ b/src/routes/backingImage/BackingImageList.js
@@ -127,6 +127,19 @@ function list({
         )
       },
     }, {
+      title: 'Data Engine',
+      dataIndex: 'dataEngine',
+      key: 'dataEngine',
+      width: 130,
+      sorter: (a, b) => a.dataEngine.toString().localeCompare(b.dataEngine.toString()),
+      render: (text) => {
+        return (
+          <div>
+            {text}
+          </div>
+        )
+      },
+    }, {
       title: 'Node Tags',
       key: 'nodeSelector',
       dataIndex: 'nodeSelector',

--- a/src/routes/backingImage/BackingImageList.js
+++ b/src/routes/backingImage/BackingImageList.js
@@ -131,7 +131,7 @@ function list({
       dataIndex: 'dataEngine',
       key: 'dataEngine',
       width: 130,
-      sorter: (a, b) => a.dataEngine.toString().localeCompare(b.dataEngine.toString()),
+      sorter: (a, b) => (a.dataEngine || '').toString().localeCompare((b.dataEngine || '').toString()),
       render: (text) => {
         return (
           <div>

--- a/src/routes/backingImage/BackupBackingImageList.js
+++ b/src/routes/backingImage/BackupBackingImageList.js
@@ -47,7 +47,7 @@ function BackupBackingImageList({ loading, dataSource, deleteBackupBackingImage,
       title: 'State',
       dataIndex: 'state',
       key: 'state',
-      width: 80,
+      width: 120,
       sorter: (a, b) => a.state.localeCompare(b.state),
       render: (text) => {
         return (
@@ -58,7 +58,7 @@ function BackupBackingImageList({ loading, dataSource, deleteBackupBackingImage,
       title: 'Backup Target',
       dataIndex: 'backupTargetName',
       key: 'backupTargetName',
-      width: 100,
+      width: 180,
       sorter: (a, b) => sortTable(a, b, 'backupTargetName'),
       render: (text) => {
         return (
@@ -71,7 +71,7 @@ function BackupBackingImageList({ loading, dataSource, deleteBackupBackingImage,
       title: 'Size',
       dataIndex: 'size',
       key: 'size',
-      width: 80,
+      width: 120,
       sorter: (a, b) => parseInt(a.size, 10) - parseInt(b.size, 10),
       render: (text) => {
         return (
@@ -100,7 +100,7 @@ function BackupBackingImageList({ loading, dataSource, deleteBackupBackingImage,
       title: 'Created Time',
       dataIndex: 'created',
       key: 'created',
-      width: 120,
+      width: 180,
       sorter: (a, b) => a.created.localeCompare(b.created),
       render: (text) => {
         return (

--- a/src/routes/backingImage/CreateBackingImage.js
+++ b/src/routes/backingImage/CreateBackingImage.js
@@ -24,6 +24,7 @@ const genDataFromType = (type, getFieldValue) => {
     name: getFieldValue('name'),
     sourceType: getFieldValue('sourceType'),
     minNumberOfCopies: getFieldValue('minNumberOfCopies'),
+    dataEngine: getFieldValue('dataEngine'),
     diskSelector: getFieldValue('diskSelector'),
     nodeSelector: getFieldValue('nodeSelector'),
   }
@@ -85,6 +86,8 @@ const modal = ({
     getFieldValue,
     setFieldsValue,
   },
+  v1DataEngineEnabled = true,
+  v2DataEngineEnabled = false
 }) => {
   function handleOk() {
     validateFields((errors) => {
@@ -309,6 +312,27 @@ const modal = ({
             ],
           })(<InputNumber min={1} />)}
         </FormItem>
+        <FormItem label="Data Engine" hasFeedback {...formItemLayout}>
+          {getFieldDecorator('dataEngine', {
+            initialValue: v2DataEngineEnabled ? 'v2' : 'v1',
+            rules: [
+              {
+                validator: (_rule, value, callback) => {
+                  if ((value === 'v1' && !v1DataEngineEnabled) || (value === 'v2' && !v2DataEngineEnabled)) {
+                    callback(`${value} data engine is not enabled`)
+                  } else {
+                    callback()
+                  }
+                },
+              },
+            ],
+          })(
+            <Select>
+              <Option value="v1">v1</Option>
+              <Option value="v2">v2</Option>
+            </Select>
+          )}
+        </FormItem>
         <Spin spinning={tagsLoading}>
           <FormItem label="Node Tag" {...formItemLayout}>
             {getFieldDecorator('nodeSelector', {
@@ -344,6 +368,8 @@ modal.propTypes = {
   nodeTags: PropTypes.array,
   diskTags: PropTypes.array,
   backingImageOptions: PropTypes.array,
+  v1DataEngineEnabled: PropTypes.bool,
+  v2DataEngineEnabled: PropTypes.bool,
 }
 
 export default Form.create()(modal)

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -117,8 +117,11 @@ class BackingImage extends React.Component {
     } = this.props.backingImage
     const { backingImageUploadPercent, backingImageUploadStarted } = this.props.app
 
-    const defaultReplicaCount = settingData.find(s => s.id === 'default-replica-count')
-    const defaultNumberOfReplicas = defaultReplicaCount ? parseInt(defaultReplicaCount.value, 10) : 3
+    const settingsMap = settingData.reduce((acc, setting = {}) => ({ ...acc, [setting.id]: setting.value }), {})
+    const v1DataEngineEnabled = settingsMap['v1-data-engine'] === 'true'
+    const v2DataEngineEnabled = settingsMap['v2-data-engine'] === 'true'
+    const defaultReplicaCount = settingsMap['default-replica-count']
+    const defaultNumberOfReplicas = defaultReplicaCount ? parseInt(defaultReplicaCount, 10) : 3
 
     const backingImages = filterBackingImage(data, biSearchField, biSearchValue)
     const volumeNameOptions = volumeData.map((volume) => volume.name)
@@ -209,6 +212,8 @@ class BackingImage extends React.Component {
       nodeTags,
       diskTags,
       tagsLoading,
+      v1DataEngineEnabled,
+      v2DataEngineEnabled,
       onOk(newBackingImage) {
         const payload = { ...newBackingImage }
         if (newBackingImage.sourceType === 'upload') {

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -117,7 +117,7 @@ class BackingImage extends React.Component {
     } = this.props.backingImage
     const { backingImageUploadPercent, backingImageUploadStarted } = this.props.app
 
-    const settingsMap = settingData.reduce((acc, setting = {}) => ({ ...acc, [setting.id]: setting.value }), {})
+    const settingsMap = Object.fromEntries(settingData.map(setting => [setting.id, setting.value]))
     const v1DataEngineEnabled = settingsMap['v1-data-engine'] === 'true'
     const v2DataEngineEnabled = settingsMap['v2-data-engine'] === 'true'
     const defaultReplicaCount = settingsMap['default-replica-count']


### PR DESCRIPTION
### What this PR does / why we need it
- [x] Add `Data Engine` select in create backing image modal
- [x] Add new column `Data Engine` to backing image table
- [x] Disable `Download` options for v2 backing image
- [x] Disable bulk action `Download` if user select one of v2 backing image

### Issue
[[UI][FEATURE] Support V2 Backing Image in UI #9880](https://github.com/longhorn/longhorn/issues/9880)

### Test Result
User are able to select `Data Engine` when create a backing image
![Screenshot 2024-12-19 at 5 25 08 PM (2)](https://github.com/user-attachments/assets/78fe1df7-3944-484c-8d56-7283cd3b3566)

Show `Data Engine` info on the table
![Screenshot 2024-12-19 at 5 25 02 PM (2)](https://github.com/user-attachments/assets/6d60822f-682e-4e8f-bb3d-23d7043493c0)

Disable `Download` options for v2 backing image
![Screenshot 2024-12-19 at 5 46 00 PM (2)](https://github.com/user-attachments/assets/334658f1-97a7-4631-9312-1fb76368f580)

Disable bulk action `Download` if user select one of v2 backing image
![Screenshot 2024-12-19 at 5 47 07 PM (2)](https://github.com/user-attachments/assets/0bdb8ab6-29dd-4400-a7c0-498e45bc33a7)

### Additional documentation or context
Test with `LONGHORN_MANAGER_IP=http://159.89.205.43:30001/ npm run dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a "Data Engine" column to the backing image list for improved visibility.
	- Introduced a new field for selecting data engine versions in the backing image creation modal, with validation logic.

- **Enhancements**
	- Modified button disabling logic for download actions based on selected rows and data engine version.
	- Increased column widths in the backup backing image list for better content display.

- **Bug Fixes**
	- Updated tooltip logic for backup actions to improve user guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->