### PR TITLE
fix: change back backing image name index to backingImageName

### DIFF
--- a/src/routes/backingImage/BackupBackingImageList.js
+++ b/src/routes/backingImage/BackupBackingImageList.js
@@ -26,10 +26,10 @@ function BackupBackingImageList({ loading, dataSource, deleteBackupBackingImage,
   const columns = [
     {
       title: 'Name',
-      dataIndex: 'name',
-      key: 'name',
+      dataIndex: 'backingImageName',
+      key: 'backingImageName',
       width: 120,
-      sorter: (a, b) => a.name.localeCompare(b.name),
+      sorter: (a, b) => a.backingImageName.localeCompare(b.backingImageName),
       render: (text, record) => {
         const isEncrypted = Boolean(record.secret || record.secretNamespace)
         return (


### PR DESCRIPTION
### What this PR does / why we need it
As [previous discussion](https://github.com/longhorn/longhorn/issues/10023#issuecomment-2559148765), change back backing image name index to backingImageName

### Issue
https://github.com/longhorn/longhorn/issues/10023

### Test Result

```
LONGHORN_MANAGER_IP=http://152.42.233.250:30001/ npm run dev
```

<img width="1495" alt="Screenshot 2024-12-24 at 11 45 37 AM" src="https://github.com/user-attachments/assets/31db3260-a6ea-48ee-b662-14057ddd8766" />

### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity in the display of backing image names.

- **Bug Fixes**
	- Fixed rendering logic to ensure proper display of date only when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->