### PR TITLE
fix: filter backups with backupTargetName

### DIFF
--- a/src/models/backup.js
+++ b/src/models/backup.js
@@ -365,8 +365,9 @@ export default {
     updateBackgroundBackups(state, action) {
       const volumeId = state.search?.keyword
       const targetBackupVolume = state.backupVolumes.find((item) => item.name === volumeId) || {}
+      // Websocket (action.payload.data) returns all backupVolumes backups, we need to filter by volumeName + backupTargetName
       if (targetBackupVolume?.volumeName && action.payload?.data) {
-        const backupData = action.payload.data.filter((item) => item.volumeName === targetBackupVolume?.volumeName)
+        const backupData = action.payload.data.filter((item) => item.volumeName === targetBackupVolume?.volumeName && item.backupTargetName === targetBackupVolume?.backupTargetName)
         return {
           ...state,
           backupData,


### PR DESCRIPTION
### What this PR does / why we need it
Fix `restore latest backup` and `create DR volume` actions with differenet backup targets from the same volume backup.

https://github.com/longhorn/longhorn-ui/pull/830#discussion_r1893380179

### Issue
https://github.com/longhorn/longhorn/issues/8647

### Test Result


```
LONGHORN_MANAGER_IP=http://152.42.233.250:30001/ npm run dev
```
<img width="1475" alt="Screenshot 2024-12-24 at 1 36 50 PM" src="https://github.com/user-attachments/assets/f16f50cf-63b7-4cf5-8f9a-7f812955b6e5" />
<img width="1494" alt="Screenshot 2024-12-24 at 1 37 05 PM" src="https://github.com/user-attachments/assets/ff81fe8c-b778-4c75-90b3-1a5d241349ad" />


### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved filtering logic for backup data to ensure accuracy by considering both `volumeName` and `backupTargetName`.
  
- **Documentation**
	- Added clarifying comments regarding the filtering logic for better understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->