### PR TITLE
feat: implement update backup target action in volume detail page

### DIFF
--- a/src/routes/volume/detail/index.js
+++ b/src/routes/volume/detail/index.js
@@ -24,6 +24,7 @@ import RecurringJob from './RecurringJob'
 import EventList from './EventList'
 import SnapshotList from './SnapshotList'
 import CloneVolume from '../CloneVolume'
+import UpdateBackupTargetModal from '../UpdateBackupTargetModal'
 import CreatePVAndPVCSingle from '../CreatePVAndPVCSingle'
 import ChangeVolumeModal from '../ChangeVolumeModal'
 import ExpansionVolumeSizeModal from '../ExpansionVolumeSizeModal'
@@ -47,6 +48,7 @@ import {
   getUpdateSnapshotMaxSizeModalProps,
   getUpdateFreezeFilesystemForSnapshotModalProps,
 } from '../helper'
+import { getBackupTargets } from '../../../utils/backupTarget'
 
 const confirm = Modal.confirm
 
@@ -132,6 +134,7 @@ function VolumeDetail({ snapshotModal, dispatch, backup, engineimage, eventlog, 
     changeVolumeModalVisible,
     previousChecked,
     volumeCloneModalVisible,
+    updateBackupTargetModalVisible,
     expansionVolumeSizeModalVisible,
     expansionVolumeSizeModalKey,
     updateDataLocalityModalVisible,
@@ -182,6 +185,7 @@ function VolumeDetail({ snapshotModal, dispatch, backup, engineimage, eventlog, 
   const v1DataEngineEnabled = v1DataEngineEnabledSetting?.value === 'true'
   const v2DataEngineEnabled = v2DataEngineEnabledSetting?.value === 'true'
 
+  const backupTargets = getBackupTargets(backupTarget)
   const eventData = getEventData(eventlog, selectedVolume)
 
   if (!selectedVolume) {
@@ -371,6 +375,14 @@ function VolumeDetail({ snapshotModal, dispatch, backup, engineimage, eventlog, 
     showUpdateAccessMode(record) {
       dispatch({
         type: 'volume/showUpdateAccessMode',
+        payload: {
+          selected: record,
+        },
+      })
+    },
+    showUpdateBackupTarget(record) {
+      dispatch({
+        type: 'volume/showUpdateBackupTarget',
         payload: {
           selected: record,
         },
@@ -658,6 +670,26 @@ function VolumeDetail({ snapshotModal, dispatch, backup, engineimage, eventlog, 
     },
   }
 
+  const updateBackupTargetModalProps = {
+    item: selectedVolume,
+    visible: updateBackupTargetModalVisible,
+    backupTargets,
+    onOk(v, url) {
+      dispatch({
+        type: 'volume/backupTargetUpdate',
+        payload: {
+          params: v,
+          url,
+        },
+      })
+    },
+    onCancel() {
+      dispatch({
+        type: 'volume/hideUpdateBackupTargetModal',
+      })
+    },
+  }
+
   const volumeCloneModalBySnapshotProps = {
     cloneType: cloneVolumeType,
     volume: selected,
@@ -718,6 +750,7 @@ function VolumeDetail({ snapshotModal, dispatch, backup, engineimage, eventlog, 
             <EventList {...eventListProps} />
           </Col>
         </Row>
+        {updateBackupTargetModalVisible && <UpdateBackupTargetModal {...updateBackupTargetModalProps} />}
         {volumeCloneModalVisible && <CloneVolume {...volumeCloneModalBySnapshotProps} />}
         {attachHostModalVisible && <AttachHost {...attachHostModalProps} />}
         {detachHostModalVisible && <DetachHost key={detachHostModalKey} {...detachHostModalProps} />}


### PR DESCRIPTION
### What this PR does / why we need it
feat: implement update backup target action in volume detail page

### Issue

https://github.com/longhorn/longhorn/issues/10045

### Test Result

https://github.com/user-attachments/assets/ea60205d-08d7-42de-b9b6-cf3db68f3bd2


### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a modal for updating backup targets within the Volume Detail component.
	- Added functionality to manage the modal's visibility and handle confirmation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->