### PR TITLE
fix: unable to delete backing image backup through UI

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -2,8 +2,13 @@ const { LH_UI_VERSION } = process.env
 
 const C = {
   RegExp: {
-    // Regular expressions ensure that only the correct request path is included
-    REQUEST: /^(https|wss)?.+?(:\d{2,6})?(?=\/v1)/,
+    // Regular expressions ensure that only the correct request path is included, scenarios:
+    // https://example.com/v1/backingimages -> /v1/backingimages
+    // http://localhost/v1/backingimages -> /v1/backingimages
+    // wss://example.com/v1/backingimages -> /v1/backingimages
+    // /v1/backingimages/v1?action=backupBackingImageCreate (no change)
+    // /v1/backupbackingimages/v1-xxx (no change)
+    REQUEST: /^(https?|wss?):\/\/[^/]+(:\d{2,6})?(?=\/v1)/,
   },
   ContainerMarginHeight: 101,
 }


### PR DESCRIPTION
### What this PR does / why we need it
- [x] Update the regex pattern to ensure the fetch URL is not incorrectly replaced

### Issue
[[BUG] Unable to delete backing image backup through UI #10047](https://github.com/longhorn/longhorn/issues/10047)

### Test Result
- Create a backing image named `v1` and back it up
- Delete the backup and verify that a success notification is displayed
- Create a volume named `v1` and back it up
- Navigate to the details page of the `v1` volume and confirm that no 404 error notifications appear

https://github.com/user-attachments/assets/d7131f48-013d-4c65-82c1-79f0f54b0258

### Additional documentation or context
Test with `LONGHORN_MANAGER_IP=http://134.209.101.112:30001/ npm run dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the validation of request paths to ensure correct URL structure.
  
- **Documentation**
	- Expanded comments to include examples of valid request paths for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->