### PR TITLE
feat: support restore v2 backing image

### DIFF
--- a/src/routes/backingImage/BackupBackingImage.js
+++ b/src/routes/backingImage/BackupBackingImage.js
@@ -18,7 +18,9 @@ function BackupBackingImage({
   dispatch,
   location = {},
   className,
-  persistFilterInURL = false
+  persistFilterInURL = false,
+  v1DataEngineEnabled = true,
+  v2DataEngineEnabled = false
 }) {
   const { pathname, hash, search } = location
 
@@ -142,6 +144,8 @@ function BackupBackingImage({
   const restoreBBiModalProps = {
     item: bbiSelected,
     visible: restoreBackupBackingImageModalVisible,
+    v1DataEngineEnabled,
+    v2DataEngineEnabled,
     onOk(item, params) {
       dispatch({
         type: 'backingImage/restoreBackingImage',
@@ -173,7 +177,7 @@ function BackupBackingImage({
         </div>
         <BackupBackingImageList {...backupBackingImageListProps} />
       </div>
-      {restoreBackupBackingImageModalVisible && <RestoreBackupBackingImageModal {...restoreBBiModalProps} />}
+      {<RestoreBackupBackingImageModal {...restoreBBiModalProps} />}
     </>
   )
 }
@@ -185,6 +189,8 @@ BackupBackingImage.propTypes = {
   dispatch: PropTypes.func,
   className: PropTypes.string,
   persistFilterInURL: PropTypes.bool,
+  v1DataEngineEnabled: PropTypes.bool,
+  v2DataEngineEnabled: PropTypes.bool,
 }
 
 export default connect(({

--- a/src/routes/backingImage/CreateBackingImage.js
+++ b/src/routes/backingImage/CreateBackingImage.js
@@ -314,7 +314,7 @@ const modal = ({
         </FormItem>
         <FormItem label="Data Engine" hasFeedback {...formItemLayout}>
           {getFieldDecorator('dataEngine', {
-            initialValue: v2DataEngineEnabled ? 'v2' : 'v1',
+            initialValue: v1DataEngineEnabled ? 'v1' : 'v2',
             rules: [
               {
                 validator: (_rule, value, callback) => {

--- a/src/routes/backingImage/RestoreBackupBackingImageModal.js
+++ b/src/routes/backingImage/RestoreBackupBackingImageModal.js
@@ -67,7 +67,7 @@ const modal = ({
         )}
          <FormItem label="Data Engine" hasFeedback {...formItemLayout}>
           {getFieldDecorator('dataEngine', {
-            initialValue: item.dataEngine || 'v1',
+            initialValue: v1DataEngineEnabled ? 'v1' : 'v2',
             rules: [
               {
                 validator: (_rule, value, callback) => {

--- a/src/routes/backingImage/RestoreBackupBackingImageModal.js
+++ b/src/routes/backingImage/RestoreBackupBackingImageModal.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Form, Input } from 'antd'
+import { Form, Input, Select, } from 'antd'
 import { ModalBlur } from '../../components'
 
-const FormItem = Form.Item
+const { Item: FormItem } = Form
+const { Option } = Select
 
 const formItemLayout = {
   labelCol: {
@@ -24,6 +25,8 @@ const modal = ({
     validateFields,
     getFieldValue,
   },
+  v1DataEngineEnabled = true,
+  v2DataEngineEnabled = false
 }) => {
   function handleOk() {
     validateFields((errors) => {
@@ -33,6 +36,7 @@ const modal = ({
       const data = {
         secret: getFieldValue('secret') || '',
         secretNamespace: getFieldValue('secretNamespace') || '',
+        dataEngine: getFieldValue('dataEngine') || 'v1'
       }
       onOk(item, data)
     })
@@ -61,6 +65,26 @@ const modal = ({
             {getFieldDecorator('secretNamespace', { initialValue: item.secretNamespace })(<Input disabled />)}
           </FormItem>
         )}
+         <FormItem label="Data Engine" hasFeedback {...formItemLayout}>
+          {getFieldDecorator('dataEngine', {
+            initialValue: item.dataEngine || 'v1',
+            rules: [
+              {
+                validator: (_rule, value, callback) => {
+                  if (value === 'v1' && !v1DataEngineEnabled) {
+                    callback('v1 data engine is not enabled')
+                  } else if (value === 'v2' && !v2DataEngineEnabled) {
+                    callback('v2 data engine is not enabled')
+                  }
+                  callback()
+                },
+              },
+            ],
+          })(<Select>
+            <Option key={'v1'} value={'v1'}>v1</Option>
+            <Option key={'v2'} value={'v2'}>v2</Option>
+          </Select>)}
+        </FormItem>
       </Form>
     </ModalBlur>
   )
@@ -72,6 +96,8 @@ modal.propTypes = {
   onCancel: PropTypes.func,
   item: PropTypes.object,
   onOk: PropTypes.func,
+  v1DataEngineEnabled: PropTypes.bool,
+  v2DataEngineEnabled: PropTypes.bool,
 }
 
 export default Form.create()(modal)

--- a/src/routes/backingImage/index.js
+++ b/src/routes/backingImage/index.js
@@ -393,7 +393,12 @@ class BackingImage extends React.Component {
           <Icon type="file-image" className="ant-breadcrumb anticon" style={{ display: 'flex', alignItems: 'center' }} />
           <span style={{ marginLeft: '4px' }}>Backing Image Backup</span>
         </div>
-        <BackupBackingImage className={style.backupBackingImage} location={location} />
+        <BackupBackingImage
+          className={style.backupBackingImage}
+          location={location}
+          v1DataEngineEnabled={v1DataEngineEnabled}
+          v2DataEngineEnabled={v2DataEngineEnabled}
+        />
         {inUploadProgress && (
           <div className={style.backingImageUploadingContainer}>
             <Progress percent={backingImageUploadPercent} />

--- a/src/routes/backup/BulkCreateStandbyVolumeModal.js
+++ b/src/routes/backup/BulkCreateStandbyVolumeModal.js
@@ -230,7 +230,7 @@ const modal = ({
         </FormItem>
         <FormItem label="Data Engine" hasFeedback {...formItemLayout}>
           {getFieldDecorator('dataEngine', {
-            initialValue: 'v1',
+            initialValue: v1DataEngineEnabled ? 'v1' : 'v2',
             rules: [
               {
                 required: true,

--- a/src/routes/backup/BulkRestoreBackupModal.js
+++ b/src/routes/backup/BulkRestoreBackupModal.js
@@ -218,7 +218,7 @@ const modal = ({
         </FormItem>
         <FormItem label="Data Engine" hasFeedback {...formItemLayout}>
           {getFieldDecorator('dataEngine', {
-            initialValue: item.dataEngine || 'v1',
+            initialValue: v1DataEngineEnabled ? 'v1' : 'v2',
             rules: [
               {
                 required: true,

--- a/src/routes/backup/CreateStandbyVolumeModal.js
+++ b/src/routes/backup/CreateStandbyVolumeModal.js
@@ -104,7 +104,7 @@ const modal = ({
         </FormItem>
         <FormItem label="Data Engine" hasFeedback {...formItemLayout}>
           {getFieldDecorator('dataEngine', {
-            initialValue: 'v1',
+            initialValue: v1DataEngineEnabled ? 'v1' : 'v2',
             rules: [
               {
                 required: true,

--- a/src/routes/backup/RestoreBackupModal.js
+++ b/src/routes/backup/RestoreBackupModal.js
@@ -109,7 +109,7 @@ const modal = ({
         </FormItem>
         <FormItem label="Data Engine" hasFeedback {...formItemLayout}>
           {getFieldDecorator('dataEngine', {
-            initialValue: 'v1',
+            initialValue: v1DataEngineEnabled ? 'v1' : 'v2',
             rules: [
               {
                 required: true,

--- a/src/routes/backup/index.js
+++ b/src/routes/backup/index.js
@@ -7,8 +7,12 @@ import BackupVolume from './BackupVolume'
 import BackupBackingImage from '../backingImage/BackupBackingImage'
 import styles from './index.less'
 
-function Backup({ dispatch, location }) {
+function Backup({ dispatch, location, setting = {} }) {
   const { pathname, hash, search } = location
+  const settingsMap = Object.fromEntries(setting.data.map(s => [s.id, s.value]))
+  const v1DataEngineEnabled = settingsMap['v1-data-engine'] === 'true'
+  const v2DataEngineEnabled = settingsMap['v2-data-engine'] === 'true'
+
   const tabs = [
     {
       key: 'volume',
@@ -19,7 +23,7 @@ function Backup({ dispatch, location }) {
       key: 'backing-image',
       label: 'Backing Image',
       content:
-        <BackupBackingImage persistFilterInURL location={location} />
+        <BackupBackingImage persistFilterInURL location={location} v1DataEngineEnabled={v1DataEngineEnabled} v2DataEngineEnabled={v2DataEngineEnabled} />
     }
   ]
   const defaultKey = tabs[0].key
@@ -55,6 +59,7 @@ function Backup({ dispatch, location }) {
 Backup.propTypes = {
   location: PropTypes.object,
   dispatch: PropTypes.func,
+  setting: PropTypes.object,
 }
 
-export default connect()(Backup)
+export default connect(({ setting }) => ({ setting }))(Backup)

--- a/src/routes/volume/BulkCloneVolumeModal.js
+++ b/src/routes/volume/BulkCloneVolumeModal.js
@@ -339,7 +339,7 @@ const modal = ({
         </FormItem>
         <FormItem label="Data Engine" hasFeedback {...formItemLayout}>
           {getFieldDecorator('dataEngine', {
-            initialValue: item.dataEngine || 'v1',
+            initialValue: v1DataEngineEnabled ? 'v1' : 'v2',
             rules: [
               {
                 validator: (_rule, value, callback) => {

--- a/src/routes/volume/CreateVolume.js
+++ b/src/routes/volume/CreateVolume.js
@@ -365,7 +365,7 @@ const modal = ({
         }
         <FormItem label="Data Engine" hasFeedback {...formItemLayout}>
           {getFieldDecorator('dataEngine', {
-            initialValue: item.dataEngine || 'v1',
+            initialValue: v1DataEngineEnabled ? 'v1' : 'v2',
             rules: [
               {
                 validator: (_rule, value, callback) => {


### PR DESCRIPTION
### What this PR does / why we need it
- [x] Add `Data Engine` select in restore backing image modal
- [x] Show option `v1` as default

### Issue
[[UI][FEATURE] Support V2 Backing Image in UI #9880](https://github.com/longhorn/longhorn/issues/9880#issuecomment-2559501498)

### Test Result
- Create a `parrot` backing image with `Data Engine: v1`
- Backup then delete the `parrot` backing image
- Restore the backup `parrot` with `Data Engine: v1`
- Observe that `parrot` is restored, then delete again
- Restore the backup `parrot` with `Data Engine: v2`
- Observe that `parrot` is restored, then delete again
- Navigate to `http://localhost:8080/#/backup#backing-image`
- Restore the backup `parrot` with `Data Engine: v1`
- Navigate to `http://localhost:8080/#/backingImage`, Observe that `parrot` is restored

https://github.com/user-attachments/assets/b1f7cc00-ee68-4509-b9c7-f6cd53e4d12e

### Additional documentation or context
Test with `LONGHORN_MANAGER_IP=http://159.89.205.43:30001/ npm run dev`
