### PR TITLE
fix: missing fromBackup parameter when bulk restore latest backup

### DIFF
--- a/src/routes/backup/BulkRestoreBackupModal.js
+++ b/src/routes/backup/BulkRestoreBackupModal.js
@@ -44,6 +44,7 @@ const modal = ({
     accessMode: i.accessMode || null,
     latestBackup: i.backupName,
     backingImage: i.backingImage,
+    fromBackup: i.fromBackup,
     encrypted: false,
     restoreVolumeRecurringJob: 'ignored',
     nodeSelector: i.nodeSelector || [],


### PR DESCRIPTION
### What this PR does / why we need it
fix: missing fromBackup parameter when bulk restore latest backup

### Issue
https://github.com/longhorn/longhorn/issues/10050
### Test Result

https://github.com/user-attachments/assets/27bf5d7e-c6c6-4fbf-be21-ff7bc5d5fbc3


### Additional documentation or context
Note. need backport to v1.8.x, v1.7.x and v1.6.x branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `fromBackup`, to enhance backup restoration configurations in the modal component.
- **Bug Fixes**
	- Improved tab switching functionality to correctly set the `fromBackup` value based on the selected item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->