### PR TITLE
fix: UI backups list hides the "next 10" buttons

### DIFF
--- a/src/routes/backup/BackupDetail.js
+++ b/src/routes/backup/BackupDetail.js
@@ -199,7 +199,7 @@ function Backup({ backup, volume, setting, backingImage, loading, location, disp
   }
 
   return (
-    <div className="content-inner" style={{ display: 'flex', flexDirection: 'column', overflow: 'visible !important' }}>
+    <div className="content-inner" style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
       <div style={{ position: 'absolute', top: '-50px', right: '20px', display: 'flex', justifyContent: 'flex-end', padding: '10px' }}>
         <DropOption
           menuOptions={[

--- a/src/routes/backup/BackupList.js
+++ b/src/routes/backup/BackupList.js
@@ -393,9 +393,8 @@ class List extends React.Component {
     }
 
     return (
-      <div id="backDetailTable" style={{ overflow: 'hidden', flex: 1 }}>
+      <div id="backDetailTable">
         <Table
-          className="common-table-class"
           locale={locale}
           bordered={false}
           columns={columns}

--- a/src/routes/backup/BackupVolumeList.js
+++ b/src/routes/backup/BackupVolumeList.js
@@ -289,9 +289,8 @@ class List extends React.Component {
     })
 
     return (
-      <div id="backTable" style={{ overflow: 'hidden', flex: 1 }}>
+      <div id="backTable">
         <Table
-          className="common-table-class"
           rowSelection={rowSelection}
           locale={locale}
           bordered={false}

--- a/src/routes/backup/backupList.less
+++ b/src/routes/backup/backupList.less
@@ -1,18 +1,41 @@
 .workloadContainer {
-    border-radius: 4px;
-    position: relative;
-    display: inline-block;
-    cursor: pointer;
-    .pod {
-        position: absolute;
-        right: 0px;
-        top: -20px;
-        left: 50%;
-        text-align: center;
-        transform: translateX(-50%);
-        height: 24px;
-        line-height: 24px;
-        overflow: hidden;
-        text-overflow:ellipsis;
+	border-radius: 4px;
+	position: relative;
+	display: inline-block;
+	cursor: pointer;
+	.pod {
+		position: absolute;
+		right: 0px;
+		top: -20px;
+		left: 50%;
+		text-align: center;
+		transform: translateX(-50%);
+		height: 24px;
+		line-height: 24px;
+		overflow: hidden;
+		text-overflow:ellipsis;
+	}
+}
+
+:global {
+  #backDetailTable {
+    height: 100%;
+
+		.ant-table-wrapper,
+    .common-table-class,
+    .ant-spin-nested-loading,
+    .ant-spin-container {
+      height: 100%;
     }
+
+    .ant-table {
+      height: calc(100% - 40px); // pagination height
+      overflow: hidden;
+
+      .ant-table-content,
+      .ant-table-scroll {
+        height: 100%;
+      }
+    }
+  }
 }

--- a/src/routes/backup/backupList.less
+++ b/src/routes/backup/backupList.less
@@ -18,10 +18,11 @@
 }
 
 :global {
+	#backTable,
   #backDetailTable {
     height: 100%;
 
-		.ant-table-wrapper,
+	.ant-table-wrapper,
     .common-table-class,
     .ant-spin-nested-loading,
     .ant-spin-container {


### PR DESCRIPTION
### What this PR does / why we need it
The user cannot navigate to the next page because the pagination is not visible. 
This PR adjusts the styles to ensure the pagination is displayed properly.

### Issue
[[BUG] UI Backups list hides the "next 10" buttons #10211](https://github.com/longhorn/longhorn/issues/10211)

### Test Result
Volume backup page
![Screenshot 2025-01-15 at 3 02 26 PM (2)](https://github.com/user-attachments/assets/d6a145ab-ed4c-4d6a-b4b2-1d2ba2dd1de7)

Volume backup detail page
![Screenshot 2025-01-15 at 3 02 31 PM (2)](https://github.com/user-attachments/assets/9271ce5a-dac3-4577-a2a2-2e538cc00f42)

### Additional documentation or context
Test with `LONGHORN_MANAGER_IP=http://134.209.101.112:30001/ npm run dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style Updates**
	- Removed `common-table-class` from multiple backup-related components
	- Updated styling for table containers to improve layout and overflow handling
	- Added global CSS rules to ensure consistent 100% height for table-related elements

- **Refactor**
	- Simplified styling approach across backup list and detail views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->