### PR TITLE
fix: unable to search by name in Volume, Node and Instance Manager pages

### DIFF
--- a/src/routes/host/HostFilter.js
+++ b/src/routes/host/HostFilter.js
@@ -76,9 +76,10 @@ class HostFilter extends React.Component {
   }
 
   render() {
-    const { location, onSearch, stateOption, fieldOption, selectedHostRows } = this.props
+    const { location, onSearch, stateOption, fieldOption, selectedHostRows, defaultField } = this.props
     const searchGroupProps = {
       location,
+      defaultField,
       stateOption,
       fieldOption,
       onSearch: (value) => {
@@ -105,6 +106,7 @@ class HostFilter extends React.Component {
 HostFilter.propTypes = {
   onSearch: PropTypes.func,
   location: PropTypes.object,
+  defaultField: PropTypes.string,
   stateOption: PropTypes.array,
   fieldOption: PropTypes.array,
   selectedHostRows: PropTypes.array,

--- a/src/routes/host/index.js
+++ b/src/routes/host/index.js
@@ -315,8 +315,9 @@ function Host({ host, volume, setting, loading, dispatch, location }) {
     replicaModalDeleteLoading,
   }
 
-  const HostFilterProps = {
+  const hostFilterProps = {
     location,
+    defaultField: 'name',
     selectedHostRows,
     dispatch,
     stateOption: [
@@ -357,7 +358,7 @@ function Host({ host, volume, setting, loading, dispatch, location }) {
 
   return (
     <div className="content-inner" style={{ display: 'flex', flexDirection: 'column', overflow: 'visible !important' }}>
-      <HostFilter ref={(component) => { hostFilter = component }} {...HostFilterProps} />
+      <HostFilter ref={(component) => { hostFilter = component }} {...hostFilterProps} />
       <HostList ref={(component) => { hostList = component }} {...hostListProps} />
       {modalVisible && <AddDisk {...addDiskModalProps} />}
       {replicaModalVisible && <HostReplica {...hostReplicaModalProps} />}

--- a/src/routes/instanceManager/index.js
+++ b/src/routes/instanceManager/index.js
@@ -62,6 +62,7 @@ class InstanceManager extends React.Component {
 
     const instanceManagerFilterProps = {
       location,
+      defaultField: 'name',
       fieldOption: [
         { value: 'name', name: 'Name' },
         { value: 'nodeID', name: 'Node' },

--- a/src/routes/volume/index.js
+++ b/src/routes/volume/index.js
@@ -637,6 +637,7 @@ class Volume extends React.Component {
 
     const volumeFilterProps = {
       location,
+      defaultField: 'name',
       stateOption: [
         { value: 'healthy', name: 'Healthy' },
         { value: 'inProgress', name: 'In Progress' },


### PR DESCRIPTION
### What this PR does / why we need it
 The search functionality by name is not working on the Volume, Node, and Instance Manager pages at first render

### Issue
[[BUG] WebUI Volumes Disappear and Reappear #10314](https://github.com/longhorn/longhorn/issues/10314#issuecomment-2632720432)

### Test Result
- Navigate to the Volume, Node and Instance Manager pages and search by Name
- The results should be displayed correctly

https://github.com/user-attachments/assets/563eabb2-fd43-4aa4-b7bb-875cf8b4cf07

### Additional documentation or context
Test with `LONGHORN_MANAGER_IP=http://134.209.101.112:30001/ npm run dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced filtering components by setting a consistent default option across host, instance management, and volume views.
  - This update streamlines the filtering experience by automatically providing an initial value, enabling users to quickly access and narrow down results without additional input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->