### PR TITLE
fix: Create button on the System Backup page is disabled after reloading page

### DIFF
--- a/src/utils/dataDependency.js
+++ b/src/utils/dataDependency.js
@@ -134,6 +134,9 @@ const dependency = {
   systemBackups: {
     path: '/systemBackups',
     runWs: [{
+      ns: 'backupTarget',
+      key: 'backuptargets',
+    }, {
       ns: 'systemBackups',
       key: 'systemBackups',
     }],


### PR DESCRIPTION
### What this PR does / why we need it
Create button on the System Backup page is disabled after reload

### Issue
[[BUG] [UI] 'Create' button on the System Backup page is disabled after reloading page #10351
](https://github.com/longhorn/longhorn/issues/10351)

### Test Result
- Navigate to `System Backup` page
- Check that the `Create` button is enabled
- Refresh the page and confirm that it remains enabled

https://github.com/user-attachments/assets/72d0a0c7-0d8c-4690-b1d2-6aab622accc2

### Additional documentation or context
Test with `LONGHORN_MANAGER_IP=http://134.209.101.112:30001/ npm run dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- Enhanced the system's backup functionality by incorporating additional backup target references, improving the reliability and consistency of backup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->