### PR TITLE
fix(ci): fixed project name for GHA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,9 @@ buildx-machine:
 # - IID_FILE_FLAG: options to generate image ID file
 .PHONY: workflow-image-build-push workflow-image-build-push-secure
 workflow-image-build-push: buildx-machine
-	MACHINE=$(MACHINE) PUSH='true' VERSION=$(VERSION) bash scripts/package
+	MACHINE=$(MACHINE) PUSH='true' VERSION=$(VERSION) IMAGE_NAME=$(NAME) bash scripts/package
 workflow-image-build-push-secure: buildx-machine
-	MACHINE=$(MACHINE) PUSH='true' VERSION=$(VERSION) IS_SECURE=true bash scripts/package
+	MACHINE=$(MACHINE) PUSH='true' VERSION=$(VERSION) IMAGE_NAME=$(NAME) IS_SECURE=true bash scripts/package
 
 stop:
 	docker stop $(NAME)-$(INSTANCE)


### PR DESCRIPTION
This change corrects the image name for GHA, to decouple the name from build environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the internal deployment pipeline by ensuring that all necessary variables for image packaging are explicitly included during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->