### PR TITLE
fix(clone): typo in handleBackupTargetNameChange

### DIFF
--- a/src/routes/volume/BulkCloneVolumeModal.js
+++ b/src/routes/volume/BulkCloneVolumeModal.js
@@ -166,7 +166,7 @@ const modal = ({
   const handleFrontendChange = (value) => updateVolumeConfig('frontend', value)
   const handleDataLocalityChange = (value) => updateVolumeConfig('dataLocality', value)
   const handleAccessModeChange = (value) => updateVolumeConfig('accessMode', value)
-  const handleBackupTargetNameChange = (value) => updateVolumeConfig('backupTargeName', value)
+  const handleBackupTargetNameChange = (value) => updateVolumeConfig('backupTargetName', value)
   const handleEncryptedCheck = (e) => updateVolumeConfig('encrypted', e.target.checked)
   const handleNodeTagRemove = (value) => {
     const oldNodeTags = volumeConfigs[tabIndex]?.nodeSelector


### PR DESCRIPTION
### What this PR does / why we need it

A typo and volume clone operation might not work well.

### Issue longhorn/longhorn#10463

### Test Result

### Additional documentation or context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the backup target name was not updating correctly in volume configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->