### PR TITLE
fix: leading or trailing spaces in Longhorn UI break search

### DIFF
--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -39,7 +39,10 @@ class Filter extends React.Component {
 
   handleSubmit = () => {
     if (this.props.onSearch) {
-      this.props.onSearch(Object.assign({}, this.state))
+      this.setState(
+        (prevState) => ({ value: prevState.value.trim() }),
+        () => this.props.onSearch({ ...this.state })
+      )
     }
   }
 


### PR DESCRIPTION
### What this PR does / why we need it
Trim the input value before submitting

### Issue
[[BUG] Leading or trailing spaces in Longhorn UI break search #10491](https://github.com/longhorn/longhorn/issues/10491)

### Test Result
- Navigate to the Volume page
- Enter a volume name with leading or trailing spaces in the search box
- Ensure the search works correctly 
- Repeat the same steps in the Node search box

![Screenshot 2025-02-26 at 1 10 49 PM (2)](https://github.com/user-attachments/assets/e6a7d251-fef7-4733-8562-7f2c8818b1b1)

### Additional documentation or context
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Refined search input handling so that any extra whitespace is automatically removed before executing a search. Users will now experience more consistent and accurate search results as the input value is cleaned up prior to processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->