### PR TITLE
feat: create Volume UI improvement, Automatically Filter Backing Image Based on v1 or v2 Selection

### DIFF
--- a/src/routes/volume/CreateVolume.js
+++ b/src/routes/volume/CreateVolume.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import {
   Form,
@@ -124,6 +124,13 @@ const modal = ({
     setFieldsValue,
   },
 }) => {
+  const [filteredBackingImages, setFilteredBackingImages] = useState([])
+
+  useEffect(() => {
+    const dataEngine = getFieldValue('dataEngine')
+    setFilteredBackingImages(backingImageOptions.filter(image => image.dataEngine === dataEngine))
+  }, [])
+
   function handleOk() {
     validateFields((errors) => {
       if (errors) {
@@ -188,6 +195,12 @@ const modal = ({
         size: formatSize(dataSourceVol),
       })
     }
+  }
+
+  // filter backing image options based on selected data engine version
+  const handleDataEngineChange = (value) => {
+    setFieldsValue({ ...getFieldsValue(), backingImage: '' }) // reset selected backing image
+    setFilteredBackingImages(backingImageOptions.filter(image => image.dataEngine === value))
   }
 
   const volumeSnapshots = snapshotsOptions?.length > 0 ? snapshotsOptions.filter(d => d.name !== 'volume-head') : []// no include volume-head
@@ -310,7 +323,7 @@ const modal = ({
           {getFieldDecorator('backingImage', {
             initialValue: '',
           })(<Select allowClear>
-            { backingImageOptions.map(backingImage => <Option key={backingImage.name} value={backingImage.name}>{backingImage.name}</Option>) }
+            { filteredBackingImages.map(backingImage => <Option key={backingImage.name} value={backingImage.name}>{backingImage.name}</Option>) }
           </Select>)}
         </FormItem>
         <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -378,7 +391,7 @@ const modal = ({
                 },
               },
             ],
-          })(<Select>
+          })(<Select onChange={handleDataEngineChange}>
             <Option key={'v1'} value={'v1'}>v1</Option>
             <Option key={'v2'} value={'v2'}>v2</Option>
           </Select>)}

--- a/src/routes/volume/CreateVolume.js
+++ b/src/routes/volume/CreateVolume.js
@@ -319,6 +319,26 @@ const modal = ({
             <Option key={'ReadWriteMany'} value={'rwx'}>ReadWriteMany</Option>
           </Select>)}
         </FormItem>
+        <FormItem label="Data Engine" hasFeedback {...formItemLayout}>
+          {getFieldDecorator('dataEngine', {
+            initialValue: v1DataEngineEnabled ? 'v1' : 'v2',
+            rules: [
+              {
+                validator: (_rule, value, callback) => {
+                  if (value === 'v1' && !v1DataEngineEnabled) {
+                    callback('v1 data engine is not enabled')
+                  } else if (value === 'v2' && !v2DataEngineEnabled) {
+                    callback('v2 data engine is not enabled')
+                  }
+                  callback()
+                },
+              },
+            ],
+          })(<Select onChange={handleDataEngineChange}>
+            <Option key={'v1'} value={'v1'}>v1</Option>
+            <Option key={'v2'} value={'v2'}>v2</Option>
+          </Select>)}
+        </FormItem>
         <FormItem label="Backing Image" hasFeedback {...formItemLayout}>
           {getFieldDecorator('backingImage', {
             initialValue: '',
@@ -376,26 +396,6 @@ const modal = ({
           )}
           </FormItem>
         }
-        <FormItem label="Data Engine" hasFeedback {...formItemLayout}>
-          {getFieldDecorator('dataEngine', {
-            initialValue: v1DataEngineEnabled ? 'v1' : 'v2',
-            rules: [
-              {
-                validator: (_rule, value, callback) => {
-                  if (value === 'v1' && !v1DataEngineEnabled) {
-                    callback('v1 data engine is not enabled')
-                  } else if (value === 'v2' && !v2DataEngineEnabled) {
-                    callback('v2 data engine is not enabled')
-                  }
-                  callback()
-                },
-              },
-            ],
-          })(<Select onChange={handleDataEngineChange}>
-            <Option key={'v1'} value={'v1'}>v1</Option>
-            <Option key={'v2'} value={'v2'}>v2</Option>
-          </Select>)}
-        </FormItem>
         <FormItem label="Backup Target" hasFeedback {...formItemLayout}>
           {getFieldDecorator('backupTargetName', {
             // init backup target is the default one


### PR DESCRIPTION
### What this PR does / why we need it
- Auto filter backing images by data engine version
- Move the data engine selector above backing image for better UX

### Issue
[[IMPROVEMENT] Create Volume UI improvement, Automatically Filter Backing Image Based on v1 or v2 Selection #10086
](https://github.com/longhorn/longhorn/issues/10086)

### Test Result
- Create a volume, the `Backing Image` options should be filtered based on the selected `Data Engine` version
- Select a `Backing Image`, then switch the `Data Engine`
- The `Backing Image` selection should reset and display the corresponding options

https://github.com/user-attachments/assets/24f5e7cf-b9ed-422d-aa37-1c20ee735a9d

### Additional documentation or context
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The volume creation modal now dynamically filters backing image options based on the selected data engine, ensuring users see only the most relevant options during setup. 
	- Added functionality to reset the selected backing image when the data engine changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->