### PR TITLE
feat: do not display backup size of 0 for in-progress backup 

### DIFF
--- a/src/components/Snapshot/Snapshot.js
+++ b/src/components/Snapshot/Snapshot.js
@@ -168,7 +168,11 @@ function SnapshotIcon(props, snapshotProps) {
         title={<div>
         <p className="snapshot-name">Name: {snapshotObject.name}</p>
         <p className="snapshot-created">Created: {snapshotObject.created}</p>
-        <p className="snapshot-name">Size: {backupStatusObject && backupStatusObject.size ? formatMib(backupStatusObject.size) : formatMib(snapshotObject.size)}</p>
+        {(backupStatusObject?.size || snapshotObject?.size) > 0 && (
+          <p className="snapshot-name">
+            Size: {backupStatusObject?.size ? formatMib(backupStatusObject.size) : formatMib(snapshotObject.size)}
+          </p>
+        )}
         <p className="snapshot-name">Created By User: {snapshotObject.usercreated ? 'True' : 'False'}</p>
         <p className="snapshot-name">Removed: {snapshotObject.removed ? 'True' : 'False'}</p>
         {

--- a/src/components/Snapshot/Snapshot.js
+++ b/src/components/Snapshot/Snapshot.js
@@ -168,11 +168,7 @@ function SnapshotIcon(props, snapshotProps) {
         title={<div>
         <p className="snapshot-name">Name: {snapshotObject.name}</p>
         <p className="snapshot-created">Created: {snapshotObject.created}</p>
-        {(backupStatusObject?.size || snapshotObject?.size) > 0 && (
-          <p className="snapshot-name">
-            Size: {backupStatusObject?.size ? formatMib(backupStatusObject.size) : formatMib(snapshotObject.size)}
-          </p>
-        )}
+        <p className="snapshot-name">Size: {backupStatusObject && backupStatusObject.progress === 100 ? formatMib(backupStatusObject.size) : formatMib(snapshotObject.size)}</p>
         <p className="snapshot-name">Created By User: {snapshotObject.usercreated ? 'True' : 'False'}</p>
         <p className="snapshot-name">Removed: {snapshotObject.removed ? 'True' : 'False'}</p>
         {


### PR DESCRIPTION
### What this PR does / why we need it
- Only display the size of the backup once progress is 100

### Issue
[[IMPROVEMENT] Do not display backup size of 0 for in-progress backup #9783](https://github.com/longhorn/longhorn/issues/9783)

### Test Result
When taking a backup:
* First, a snapshot will appear. We should display the snapshot and its size
* Then a backup will appear. 
* The backup might have null progress
* If the size of backup is 0. Do not display the size of the backup
* Only display the size of the backup once progress is 100 

**When the snapshot size starts at 0**

https://github.com/user-attachments/assets/fd6ea522-5f8f-4ba2-a2b4-58845f7e73ea

**When the snapshot size starts greater than 0**

https://github.com/user-attachments/assets/27711be7-1862-4d81-91c6-69ab65d997ee



### Additional documentation or context
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the snapshot size display to show the size only when it is a positive value, resulting in clearer and more accurate information for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->