### PR TITLE
feat: improve the Warning Message When Failed to Remove Block-Type Disks

### DIFF
--- a/src/routes/host/components/EditableDiskItem.js
+++ b/src/routes/host/components/EditableDiskItem.js
@@ -26,7 +26,7 @@ function EditableDiskItem({ isNew, disk, form, onRestore, onRemove, validatePath
     } else if (canBeRemoved()) {
       return (<a onClick={() => onRemove(disk.id)}><IconRemove /></a>)
     }
-    return <Tooltip placement="top" title="Only the disk with disabled scheduling and no storage scheduled can be deleted"><span><IconRemove disabled /></span></Tooltip>
+    return <Tooltip placement="top" title="To delete this disk, disable scheduling and ensure that no replicas and backing images are in use"><span><IconRemove disabled /></span></Tooltip>
   }
 
   // Because the parameters passed need to be retained, the content of the form is retained


### PR DESCRIPTION
### What this PR does / why we need it
- Update the tooltip wording for improved clarity

### Issue
[[UI][IMPROVEMENT] Improve the Warning Message When Failed to Remove Block-Type Disks #10580
](https://github.com/longhorn/longhorn/issues/10580)

### Test Result
- Go to Node page and click `Edit node and disks`
- Hover over the trash icon, and the tooltip should display `To delete this disk, disable scheduling and ensure no replicas or backing images are in use`

![Screenshot 2025-03-14 at 1 29 13 PM (2)](https://github.com/user-attachments/assets/98e5abc1-e56b-46d1-9e16-33e0ca345655)

### Additional documentation or context
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the tooltip text for disk deletion to clearly instruct users to disable scheduling and ensure that no replicas or backing images are in use before deletion. This change enhances clarity and improves the overall user guidance without altering the underlying functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->