### PR TITLE
fix: inconsistent capitalization in the Allow snapshots removal during trim volume setting 

### DIFF
--- a/src/routes/volume/UpdateBulkUnmapMarkSnapChainRemovedModal.js
+++ b/src/routes/volume/UpdateBulkUnmapMarkSnapChainRemovedModal.js
@@ -41,7 +41,7 @@ const modal = ({
   }
 
   const modalOpts = {
-    title: 'Allow snapshots removal during trim',
+    title: 'Allow Snapshots Removal During Trim',
     visible,
     onCancel,
     width: 600,

--- a/src/routes/volume/UpdateUnmapMarkSnapChainRemovedModal.js
+++ b/src/routes/volume/UpdateUnmapMarkSnapChainRemovedModal.js
@@ -41,7 +41,7 @@ const modal = ({
   }
 
   const modalOpts = {
-    title: 'Allow snapshots removal during trim',
+    title: 'Allow Snapshots Removal During Trim',
     visible,
     onCancel,
     width: 600,

--- a/src/routes/volume/VolumeActions.js
+++ b/src/routes/volume/VolumeActions.js
@@ -229,7 +229,7 @@ function actions({
     { key: 'updateAccessMode', name: 'Update Access Mode', disabled: (selected.kubernetesStatus && selected.kubernetesStatus.pvStatus) || !canUpdateAccessMode() },
     { key: 'updateBackupTargetName', name: 'Update Backup Target' },
     { key: 'updateReplicaAutoBalance', name: 'Update Replicas Auto Balance', disabled: !canUpdateReplicaAutoBalance() },
-    { key: 'updateUnmapMarkSnapChainRemoved', name: 'Allow snapshots removal during trim', disabled: false },
+    { key: 'updateUnmapMarkSnapChainRemoved', name: 'Allow Snapshots Removal During Trim', disabled: false },
     { key: 'updateReplicaSoftAntiAffinity', name: 'Update Replica Soft Anti Affinity', disabled: false },
     { key: 'updateReplicaZoneSoftAntiAffinity', name: 'Update Replica Zone Soft Anti Affinity', disabled: false },
     { key: 'updateSnapshotMaxCount', name: 'Update Snapshot Max Count', disabled: false },

--- a/src/routes/volume/VolumeBulkActions.js
+++ b/src/routes/volume/VolumeBulkActions.js
@@ -208,7 +208,7 @@ function bulkActions({
     { key: 'updateReplicaAutoBalance', name: 'Update Replicas Auto Balance', disabled() { return selectedRows.length === 0 || disableUpdateReplicaAutoBalance() } },
     { key: 'createPVAndPVC', name: 'Create PV/PVC', disabled() { return selectedRows.length === 0 || isHasStandy() || hasVolumeRestoring() || isHasPVC() || isFaulted() || !hasAction('pvCreate') || !hasAction('pvcCreate') } },
     { key: 'bulkChangeVolume', name: 'Activate Disaster Recovery Volume', disabled() { return selectedRows.length === 0 || selectedRows.some((item) => !item.standby) } },
-    { key: 'updateUnmapMarkSnapChainRemoved', name: 'Allow snapshots removal during trim', disabled() { return selectedRows.length === 0 } },
+    { key: 'updateUnmapMarkSnapChainRemoved', name: 'Allow Snapshots Removal During Trim', disabled() { return selectedRows.length === 0 } },
     { key: 'updateReplicaSoftAntiAffinity', name: 'Update Replica Soft Anti Affinity', disabled() { return selectedRows.length === 0 } },
     { key: 'updateReplicaZoneSoftAntiAffinity', name: 'Update Replica Zone Soft Anti Affinity', disabled() { return selectedRows.length === 0 } },
     { key: 'updateReplicaDiskSoftAntiAffinity', name: 'Update Replica Disk Soft Anti Affinity', disabled() { return selectedRows.length === 0 } },

--- a/src/routes/volume/detail/VolumeInfo.js
+++ b/src/routes/volume/detail/VolumeInfo.js
@@ -355,7 +355,7 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
         {selectedVolume.controllers ? selectedVolume.controllers.filter(item => item.instanceManagerName !== '').map(item => <div key={item.hostId} style={{ fontFamily: 'monospace', margin: '2px 0px' }}> <span style={{ backgroundColor: '#f2f4f5' }}> {item.instanceManagerName} </span></div>) : ''}
       </div>
       <div className={styles.row}>
-        <span className={styles.label}> Allow snapshots removal during trim:</span>
+        <span className={styles.label}> Allow Snapshots Removal During Trim:</span>
         {addGlobalSettingDescription(selectedVolume?.unmapMarkSnapChainRemoved)}
       </div>
       <div className={styles.row}>


### PR DESCRIPTION
### What this PR does / why we need it
- Unify the capitalization of `Allow Snapshots Removal During Trim` across the application

### Issue
[[BUG][UI] Inconsistent capitalization in the Allow snapshots removal during trim volume setting #10470
](https://github.com/longhorn/longhorn/issues/10470)

### Test Result
- Verify that `Allow Snapshots Removal During Trim` is consistent across the application

Volume action
![Screenshot 2025-03-14 at 2 17 09 PM (2)](https://github.com/user-attachments/assets/2a940bf1-bcdd-4625-8cf2-ed6a65500cc8)

Volume bulk action
![Screenshot 2025-03-14 at 1 58 25 PM (2)](https://github.com/user-attachments/assets/86064003-877a-4e67-ab7a-31949ba5a375)

Volume action modal
![Screenshot 2025-03-14 at 2 05 49 PM (2)](https://github.com/user-attachments/assets/e307d008-481e-4b6d-99f0-3398a0d374ef)

Volume action on detail page
![Screenshot 2025-03-14 at 1 56 12 PM (2)](https://github.com/user-attachments/assets/fe9980d0-d80b-4a67-816f-4f6e5e31d2d2)

Volume action modal on detail page
![Screenshot 2025-03-14 at 1 57 42 PM (2)](https://github.com/user-attachments/assets/385fefff-7e6d-4944-af76-f8697fff087d)

Volume info on detail page
![Screenshot 2025-03-14 at 1 59 32 PM (2)](https://github.com/user-attachments/assets/1e874432-9499-4054-a773-cfae86d19242)

### Additional documentation or context
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved the visual presentation by updating capitalization in snapshot removal actions, modals, and labels for better clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->