### PR TITLE
fix: expand volume option is greyed under Volume tab but working in the volume detail section

### DIFF
--- a/src/routes/volume/VolumeActions.js
+++ b/src/routes/volume/VolumeActions.js
@@ -248,7 +248,7 @@ function actions({
   })
 
   availableActions.push({ key: 'cloneVolume', name: 'Clone Volume', disabled: selected.standby || isRestoring(selected) })
-  availableActions.push({ key: 'expandVolume', name: 'Expand Volume', disabled: selected?.conditions?.Scheduled?.status?.toLowerCase() === 'false' })
+  availableActions.push({ key: 'expandVolume', name: 'Expand Volume', disabled: selected?.conditions?.Scheduled?.status?.toLowerCase() !== 'true' })
   if (selected.controllers && selected.controllers[0] && !selected.controllers[0].isExpanding && selected.controllers[0].size !== 0 && selected.controllers[0].size !== selected.size && selected.controllers[0].size !== '0') {
     availableActions.push({ key: 'cancelExpansion', name: 'Cancel Expansion', disabled: false })
   }

--- a/src/routes/volume/VolumeBulkActions.js
+++ b/src/routes/volume/VolumeBulkActions.js
@@ -181,7 +181,7 @@ function bulkActions({
       return false
     })
   }
-  const conditionsScheduled = () => selectedRows.some(item => item.conditions && item.conditions.Scheduled && item.conditions.Scheduled.status && item.conditions.Scheduled.status.toLowerCase() === 'true')
+  const disableExpandVolume = () => selectedRows.some(item => item.conditions?.Scheduled?.status?.toLowerCase() !== 'true')
   const upgradingEngine = () => selectedRows.some((item) => item.currentImage !== item.image)
   const notAttached = () => selectedRows.some(item => item.state !== 'attached')
   /*
@@ -199,7 +199,7 @@ function bulkActions({
 
   const allDropDownActions = [
     { key: 'upgrade', name: 'Upgrade Engine', disabled() { return selectedRows.length === 0 || isAutomaticallyUpgradeEngine() || !hasAction('engineUpgrade') || hasDoingState() || hasMoreOptions() || hasVolumeRestoring() || canUpgradeEngine() } },
-    { key: 'expandVolume', name: 'Expand Volume', disabled() { return selectedRows.length === 0 || !conditionsScheduled() } },
+    { key: 'expandVolume', name: 'Expand Volume', disabled() { return selectedRows.length === 0 || disableExpandVolume() } },
     { key: 'updateBulkReplicaCount', name: 'Update Replicas Count', disabled() { return selectedRows.length === 0 || isHasStandy() || disableUpdateBulkReplicaCount() || upgradingEngine() } },
     { key: 'updateBulkDataLocality', name: 'Update Data Locality', disabled() { return selectedRows.length === 0 || isHasStandy() || disableUpdateBulkDataLocality() || upgradingEngine() } },
     { key: 'updateSnapshotDataIntegrity', name: 'Snapshot Data Integrity', disabled() { return selectedRows.length === 0 } },


### PR DESCRIPTION
### What this PR does / why we need it
- `Expand Volume` should be consistent across the volume details page and bulk actions
- `Expand Volume` should be enabled for detached volume

### Issue
[[BUG] Expand Volume option is greyed under Volume tab but working in the volume detail section.  #7529
](https://github.com/longhorn/longhorn/issues/7529)

### Test Result
- Go to the volume page
- Select a detached volume and click on bulk actions
- In the dropdown menu, the `Expand Volume` option should be enabled
- Navigate to the volume details page, and the `Expand Volume` should also be enabled there

![Screenshot 2025-03-18 at 1 26 13 PM (2)](https://github.com/user-attachments/assets/8675e360-b294-4014-9bc7-715ad77c630c)
![Screenshot 2025-03-18 at 1 31 47 PM (2)](https://github.com/user-attachments/assets/e005476e-5f79-4bd4-9ab2-4ac7cb641a26)

### Additional documentation or context
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the conditions for the "Expand Volume" action to enable it when the volume is not actively scheduled, enhancing the consistency of the action’s availability and preventing unintended expansion based on the volume’s scheduling status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->