### PR TITLE
fix: disable bulk create backup button if any volume is detached

### DIFF
--- a/src/routes/volume/VolumeBulkActions.js
+++ b/src/routes/volume/VolumeBulkActions.js
@@ -155,7 +155,7 @@ function bulkActions({
       default:
     }
   }
-  const hasDetachedVolume = () => selectedRows.some(item => item.state === 'detached')
+  const hasNonAttachedVolume = () => selectedRows.some(item => item.state === 'detached')
   const hasAction = action => selectedRows.every(item => Object.keys(item.actions).includes(action))
   const hasDoingState = (exclusions = []) => selectedRows.some(item => (item.state.endsWith('ing') && !exclusions.includes(item.state)) || item.currentImage !== item.image)
   const isSnapshotDisabled = () => selectedRows.every(item => !item.actions || !item.actions.snapshotCreate)
@@ -193,7 +193,7 @@ function bulkActions({
     { key: 'delete', name: 'Delete', disabled() { return selectedRows.length === 0 } },
     { key: 'attach', name: 'Attach', disabled() { return selectedRows.length === 0 || selectedRows.some((item) => !attachable(item)) } },
     { key: 'detach', name: 'Detach', disabled() { return selectedRows.length === 0 || selectedRows.some((item) => !detachable(item)) } },
-    { key: 'backup', name: 'Create Backup', disabled() { return selectedRows.length === 0 || hasDetachedVolume() || isSnapshotDisabled() || hasDoingState() || isHasStandy() || hasVolumeRestoring() || !backupTargetAvailable }, toolTip: backupTargetMessage },
+    { key: 'backup', name: 'Create Backup', disabled() { return selectedRows.length === 0 || hasNonAttachedVolume() || isSnapshotDisabled() || hasDoingState() || isHasStandy() || hasVolumeRestoring() || !backupTargetAvailable }, toolTip: backupTargetMessage },
     { key: 'bulkCloneVolume', name: 'Clone Volume', disabled() { return selectedRows.length === 0 || selectedRows.every(item => item.standby || isRestoring(item)) } },
 
   ]

--- a/src/routes/volume/VolumeBulkActions.js
+++ b/src/routes/volume/VolumeBulkActions.js
@@ -155,6 +155,7 @@ function bulkActions({
       default:
     }
   }
+  const hasDetachedVolume = () => selectedRows.some(item => item.state === 'detached')
   const hasAction = action => selectedRows.every(item => Object.keys(item.actions).includes(action))
   const hasDoingState = (exclusions = []) => selectedRows.some(item => (item.state.endsWith('ing') && !exclusions.includes(item.state)) || item.currentImage !== item.image)
   const isSnapshotDisabled = () => selectedRows.every(item => !item.actions || !item.actions.snapshotCreate)
@@ -192,7 +193,7 @@ function bulkActions({
     { key: 'delete', name: 'Delete', disabled() { return selectedRows.length === 0 } },
     { key: 'attach', name: 'Attach', disabled() { return selectedRows.length === 0 || selectedRows.some((item) => !attachable(item)) } },
     { key: 'detach', name: 'Detach', disabled() { return selectedRows.length === 0 || selectedRows.some((item) => !detachable(item)) } },
-    { key: 'backup', name: 'Create Backup', disabled() { return selectedRows.length === 0 || isSnapshotDisabled() || hasDoingState() || isHasStandy() || hasVolumeRestoring() || !backupTargetAvailable }, toolTip: backupTargetMessage },
+    { key: 'backup', name: 'Create Backup', disabled() { return selectedRows.length === 0 || hasDetachedVolume() || isSnapshotDisabled() || hasDoingState() || isHasStandy() || hasVolumeRestoring() || !backupTargetAvailable }, toolTip: backupTargetMessage },
     { key: 'bulkCloneVolume', name: 'Clone Volume', disabled() { return selectedRows.length === 0 || selectedRows.every(item => item.standby || isRestoring(item)) } },
 
   ]

--- a/src/routes/volume/VolumeBulkActions.js
+++ b/src/routes/volume/VolumeBulkActions.js
@@ -155,7 +155,7 @@ function bulkActions({
       default:
     }
   }
-  const hasNonAttachedVolume = () => selectedRows.some(item => item.state === 'detached')
+  const hasNonAttachedVolume = () => selectedRows.some(item => item.state !== 'attached')
   const hasAction = action => selectedRows.every(item => Object.keys(item.actions).includes(action))
   const hasDoingState = (exclusions = []) => selectedRows.some(item => (item.state.endsWith('ing') && !exclusions.includes(item.state)) || item.currentImage !== item.image)
   const isSnapshotDisabled = () => selectedRows.every(item => !item.actions || !item.actions.snapshotCreate)


### PR DESCRIPTION
### What this PR does / why we need it
fix: disable bulk Create Backup button if any volume is detached

### Issue
https://github.com/longhorn/longhorn/issues/10460

### Test Result

If all volumes are attached, enable button

<img width="1493" alt="Screenshot 2025-04-14 at 3 02 16 PM" src="https://github.com/user-attachments/assets/861a99a8-75d8-4ce8-8d2b-7e92b243a787" />

If any volume is detached, disable button

<img width="1496" alt="Screenshot 2025-04-14 at 3 01 56 PM" src="https://github.com/user-attachments/assets/13b46b18-80af-439f-b842-da5a262968a6" />

### Additional documentation or context
