### PR TITLE
feat: v2 volume supports UBLK frontend

### DIFF
--- a/src/routes/volume/CreateVolume.js
+++ b/src/routes/volume/CreateVolume.js
@@ -130,7 +130,6 @@ const modal = ({
     const dataEngine = getFieldValue('dataEngine')
     setFilteredBackingImages(backingImageOptions.filter(image => image.dataEngine === dataEngine))
   }, [])
-
   function handleOk() {
     validateFields((errors) => {
       if (errors) {
@@ -197,10 +196,11 @@ const modal = ({
     }
   }
 
-  // filter backing image options based on selected data engine version
+  // filter options based on selected data engine version
   const handleDataEngineChange = (value) => {
     setFieldsValue({ ...getFieldsValue(), backingImage: '' }) // reset selected backing image
     setFilteredBackingImages(backingImageOptions.filter(image => image.dataEngine === value))
+    setFieldsValue({ ...getFieldsValue(), frontend: frontends[0].value }) // reset selected frontend
   }
 
   const volumeSnapshots = snapshotsOptions?.length > 0 ? snapshotsOptions.filter(d => d.name !== 'volume-head') : []// no include volume-head
@@ -291,34 +291,6 @@ const modal = ({
             ],
           })(<InputNumber />)}
         </FormItem>
-        <FormItem label="Frontend" hasFeedback {...formItemLayout}>
-          {getFieldDecorator('frontend', {
-            initialValue: frontends[0].value,
-            rules: [
-              {
-                required: true,
-                message: 'Please select a frontend',
-              },
-            ],
-          })(<Select>
-          { frontends.map(opt => <Option key={opt.value} value={opt.value}>{opt.label}</Option>) }
-          </Select>)}
-        </FormItem>
-        <FormItem label="Data Locality" hasFeedback {...formItemLayout}>
-          {getFieldDecorator('dataLocality', {
-            initialValue: defaultDataLocalityValue,
-          })(<Select>
-          { defaultDataLocalityOption.map(value => <Option key={value} value={value}>{value}</Option>) }
-          </Select>)}
-        </FormItem>
-        <FormItem label="Access Mode" hasFeedback {...formItemLayout}>
-          {getFieldDecorator('accessMode', {
-            initialValue: 'rwo',
-          })(<Select>
-            <Option key={'ReadWriteOnce'} value={'rwo'}>ReadWriteOnce</Option>
-            <Option key={'ReadWriteMany'} value={'rwx'}>ReadWriteMany</Option>
-          </Select>)}
-        </FormItem>
         <FormItem label="Data Engine" hasFeedback {...formItemLayout}>
           {getFieldDecorator('dataEngine', {
             initialValue: v1DataEngineEnabled ? 'v1' : 'v2',
@@ -339,11 +311,44 @@ const modal = ({
             <Option key={'v2'} value={'v2'}>v2</Option>
           </Select>)}
         </FormItem>
+        <FormItem label="Frontend" hasFeedback {...formItemLayout}>
+          {getFieldDecorator('frontend', {
+            initialValue: frontends[0].value,
+            rules: [
+              {
+                required: true,
+                message: 'Please select a frontend',
+              },
+            ],
+          })(<Select>
+          {frontends.map(({ value, label, dataEngine }) => {
+            const selectedDataEngine = getFieldValue('dataEngine')
+            return dataEngine.includes(selectedDataEngine)
+              ? <Option key={value} value={value}>{label}</Option>
+              : null
+          })}
+          </Select>)}
+        </FormItem>
+        <FormItem label="Data Locality" hasFeedback {...formItemLayout}>
+          {getFieldDecorator('dataLocality', {
+            initialValue: defaultDataLocalityValue,
+          })(<Select>
+          { defaultDataLocalityOption.map(value => <Option key={value} value={value}>{value}</Option>) }
+          </Select>)}
+        </FormItem>
+        <FormItem label="Access Mode" hasFeedback {...formItemLayout}>
+          {getFieldDecorator('accessMode', {
+            initialValue: 'rwo',
+          })(<Select>
+            <Option key={'ReadWriteOnce'} value={'rwo'}>ReadWriteOnce</Option>
+            <Option key={'ReadWriteMany'} value={'rwx'}>ReadWriteMany</Option>
+          </Select>)}
+        </FormItem>
         <FormItem label="Backing Image" hasFeedback {...formItemLayout}>
           {getFieldDecorator('backingImage', {
             initialValue: '',
           })(<Select allowClear>
-            { filteredBackingImages.map(backingImage => <Option key={backingImage.name} value={backingImage.name}>{backingImage.name}</Option>) }
+              { filteredBackingImages.map(backingImage => <Option key={backingImage.name} value={backingImage.name}>{backingImage.name}</Option>) }
           </Select>)}
         </FormItem>
         <div style={{ display: 'flex', flexDirection: 'column' }}>

--- a/src/routes/volume/helper/index.js
+++ b/src/routes/volume/helper/index.js
@@ -711,8 +711,10 @@ export function needToWaitDone(state, replicas) {
 }
 
 export const frontends = [
-  { label: 'Block Device', value: 'blockdev' },
-  { label: 'iSCSI', value: 'iscsi' },
+  { label: 'Block Device', value: 'blockdev', dataEngine: ['v1', 'v2'] },
+  { label: 'iSCSI', value: 'iscsi', dataEngine: ['v1'] },
+  { label: 'NVMF', value: 'nvmf', dataEngine: ['v2'] },
+  { label: 'UBLK', value: 'ublk', dataEngine: ['v2'] },
 ]
 
 export function disabledSnapshotAction(volume, modelState) {

--- a/src/routes/volume/helper/index.js
+++ b/src/routes/volume/helper/index.js
@@ -713,7 +713,7 @@ export function needToWaitDone(state, replicas) {
 export const frontends = [
   { label: 'Block Device', value: 'blockdev', dataEngine: ['v1', 'v2'] },
   { label: 'iSCSI', value: 'iscsi', dataEngine: ['v1'] },
-  { label: 'NVMF', value: 'nvmf', dataEngine: ['v2'] },
+  { label: 'NVMf', value: 'nvmf', dataEngine: ['v2'] },
   { label: 'UBLK', value: 'ublk', dataEngine: ['v2'] },
 ]
 


### PR DESCRIPTION
### What this PR does / why we need it
- Add the `Frontend` options during volume creation based on the selected data engine version
- Display the `Frontend` setting `UBLK` on the volume details page

### Issue
[[TASK] [UI] [FEATURE] v2 volume supports UBLK frontend #10735](https://github.com/longhorn/longhorn/issues/10735#issuecomment-2817729136)

### Test Result
1. Ensure the `UBLK` kernel module is loaded on each node by running `modprobe ublk_drv`
2. Navigate to the volume page and click on `Create Volume`
3. In the popup modal:
   - For `v1` data engine, only the following `Frontend` options should be available:
     - `Block Device`
     - `iSCSI`
   - For `v2` data engine, the following `Frontend` options should be available:
     - `Block Device`
     - `NVMf `
     - `UBLK`
4. Select the `v2` data engine and choose `UBLK` as the frontend
5. Attach the volume, it should attach successfully
6. Go to the volume detail page, the `Frontend: UBLK` should be displayed in the `Volume Details` section

https://github.com/user-attachments/assets/f4e60b9e-1474-4b71-a496-560216d529a4

### Additional documentation or context
N/A
