### PR TITLE
refactor: change Orphaned Data page wordings

### DIFF
--- a/src/routes/orphanedData/index.js
+++ b/src/routes/orphanedData/index.js
@@ -14,12 +14,12 @@ function OrphanedData({ dispatch, location }) {
   const tabs = [
     {
       key: ORPHAN_TYPES.REPLICA_DATA,
-      label: 'Replica Data Orphans',
+      label: 'Replica Data',
       content: <ReplicaDataOrphans location={location} />,
     },
     {
       key: 'instance',
-      label: 'Instance Orphans',
+      label: 'Instances',
       content: <InstanceOrphans location={location} />,
     },
   ]

--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -56,7 +56,7 @@ module.exports = [
       {
         show: true,
         key: 'orphanedData',
-        name: 'Orphans',
+        name: 'Orphan Resources',
         icon: 'profile',
       },
       {

--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -56,7 +56,7 @@ module.exports = [
       {
         show: true,
         key: 'orphanedData',
-        name: 'Orphaned Data',
+        name: 'Orphans',
         icon: 'profile',
       },
       {


### PR DESCRIPTION
### What this PR does / why we need it
Change the wording based on demo feedback
- Rename the `Orphaned Data` page
- Update the tabs to remove the term `orphans`

### Issue
N/A

### Test Result
![Screenshot 2025-05-07 at 10 19 09 AM (2)](https://github.com/user-attachments/assets/cb4cbb20-5bc6-4af3-be68-bd7ba0a3e06f)


### Additional documentation or context
N/A
