### PR TITLE
feat(container-image): enable IPv6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ RUN mkdir -p /var/config/ && touch /var/run/nginx.pid && chown -R 499 /var/confi
 # Use the uid of the default user (nginx) from the installed nginx package
 USER 499
 
-CMD ["/bin/bash", "-c", "mkdir -p /var/config/nginx/ && cp -r /etc/nginx/* /var/config/nginx/; envsubst '${LONGHORN_MANAGER_IP},${LONGHORN_UI_PORT}' < /etc/nginx/nginx.conf.template > /var/config/nginx/nginx.conf && nginx -c /var/config/nginx/nginx.conf -g 'daemon off;'"]
+CMD ["/bin/bash", "-c", "mkdir -p /var/config/nginx/ && cp -r /etc/nginx/* /var/config/nginx/; envsubst '${LONGHORN_MANAGER_IP},${LONGHORN_UI_PORT}' < /etc/nginx/nginx.conf.template > /var/config/nginx/nginx.conf && sed -i 's/listen 8000;/listen 0.0.0.0:8000; listen [::]:8000;/g' /var/config/nginx/nginx.conf && nginx -c /var/config/nginx/nginx.conf -g 'daemon off;'"]


### PR DESCRIPTION
### What this PR does / why we need it

This enables the IPv6 capability in the container image.
It uses dual stack by default, insofar uses IPv6 when available.

### Issue

The ui cannot be reached via IPv6.

### Test Result

Tested and works.

### Additional documentation or context

- https://www.cyberciti.biz/faq/nginx-ipv6-configuration/
