### PR TITLE
feat: restructure the navigation menus

### DIFF
--- a/src/components/Layout/Menu.js
+++ b/src/components/Layout/Menu.js
@@ -16,7 +16,6 @@ const getMenus = function (menuArray, siderFold) {
         <SubMenu key={linkTo.pathname}
           title={
             <span>
-              {item.icon ? <Icon type={item.icon} /> : ''}
               {siderFold && topMenus.indexOf(item.key) >= 0 ? '' : item.name}
               <Icon type="down" style={{ marginLeft: 5 }} />
             </span>
@@ -28,7 +27,6 @@ const getMenus = function (menuArray, siderFold) {
       menus = (
         <Menu.Item key={linkTo.pathname}>
           <LinkTo to={linkTo}>
-            {item.icon ? <Icon type={item.icon} /> : ''}
             {siderFold && topMenus.indexOf(item.key) >= 0 ? '' : item.name}
           </LinkTo>
         </Menu.Item>

--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -26,20 +26,46 @@ module.exports = [
     icon: 'history',
   },
   {
-    key: 'backup',
-    name: 'Backup',
-    icon: 'copy',
-  },
-  {
-    key: 'setting',
-    name: 'Setting',
-    icon: 'setting',
+    key: 'backupAndRestore',
+    name: 'Backup and Restore',
+    icon: 'cloud-sync',
     child: [
       {
         show: true,
-        key: 'setting',
-        name: 'General',
-        icon: 'setting',
+        key: 'backup',
+        name: 'Backup',
+        icon: 'copy',
+      },
+      {
+        show: true,
+        key: 'backupTarget',
+        name: 'Backup Target',
+        icon: 'cloud-server',
+      },
+      {
+        show: true,
+        key: 'systemBackups',
+        name: 'System Backup',
+        icon: 'file-sync',
+      },
+    ],
+  },
+  {
+    key: 'advanced',
+    name: 'Advanced',
+    icon: 'bars',
+    child: [
+      {
+        show: true,
+        key: 'backingImage',
+        name: 'Backing Image',
+        icon: 'file-image',
+      },
+      {
+        show: true,
+        key: 'orphanedData',
+        name: 'Orphan Resources',
+        icon: 'profile',
       },
       {
         show: true,
@@ -55,34 +81,15 @@ module.exports = [
       },
       {
         show: true,
-        key: 'orphanedData',
-        name: 'Orphan Resources',
-        icon: 'profile',
-      },
-      {
-        show: true,
-        key: 'backingImage',
-        name: 'Backing Image',
-        icon: 'file-image',
-      },
-      {
-        show: true,
-        key: 'backupTarget',
-        name: 'Backup Target',
-        icon: 'cloud-server',
-      },
-      {
-        show: true,
         key: 'instanceManager',
         name: 'Instance Manager Image',
         icon: 'apartment',
       },
-      {
-        show: true,
-        key: 'systemBackups',
-        name: 'System Backup',
-        icon: 'file-sync',
-      },
     ],
+  },
+  {
+    key: 'setting',
+    name: 'Setting',
+    icon: 'setting',
   },
 ]

--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -5,11 +5,11 @@ module.exports = [
   },
   {
     key: 'node',
-    name: 'Node',
+    name: 'Nodes',
   },
   {
     key: 'volume',
-    name: 'Volume',
+    name: 'Volumes',
     child: [
       {
         key: 'detail',
@@ -19,7 +19,7 @@ module.exports = [
   },
   {
     key: 'recurringJob',
-    name: 'Recurring Job',
+    name: 'Recurring Jobs',
   },
   {
     key: 'backupAndRestore',
@@ -28,17 +28,17 @@ module.exports = [
       {
         show: true,
         key: 'backup',
-        name: 'Backup',
+        name: 'Backups',
       },
       {
         show: true,
         key: 'backupTarget',
-        name: 'Backup Target',
+        name: 'Backup Targets',
       },
       {
         show: true,
         key: 'systemBackups',
-        name: 'System Backup',
+        name: 'System Backups',
       },
     ],
   },
@@ -49,7 +49,7 @@ module.exports = [
       {
         show: true,
         key: 'backingImage',
-        name: 'Backing Image',
+        name: 'Backing Images',
       },
       {
         show: true,
@@ -59,7 +59,7 @@ module.exports = [
       {
         show: true,
         key: 'engineimage',
-        name: 'Engine Image',
+        name: 'Engine Images',
         child: [
           {
             key: 'detail',
@@ -70,7 +70,7 @@ module.exports = [
       {
         show: true,
         key: 'instanceManager',
-        name: 'Instance Manager Image',
+        name: 'Instance Manager Images',
       },
     ],
   },

--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -2,17 +2,14 @@ module.exports = [
   {
     key: 'dashboard',
     name: 'Dashboard',
-    icon: 'bar-chart',
   },
   {
     key: 'node',
     name: 'Node',
-    icon: 'laptop',
   },
   {
     key: 'volume',
     name: 'Volume',
-    icon: 'database',
     child: [
       {
         key: 'detail',
@@ -23,55 +20,46 @@ module.exports = [
   {
     key: 'recurringJob',
     name: 'Recurring Job',
-    icon: 'history',
   },
   {
     key: 'backupAndRestore',
     name: 'Backup and Restore',
-    icon: 'cloud-sync',
     child: [
       {
         show: true,
         key: 'backup',
         name: 'Backup',
-        icon: 'copy',
       },
       {
         show: true,
         key: 'backupTarget',
         name: 'Backup Target',
-        icon: 'cloud-server',
       },
       {
         show: true,
         key: 'systemBackups',
         name: 'System Backup',
-        icon: 'file-sync',
       },
     ],
   },
   {
     key: 'advanced',
     name: 'Advanced',
-    icon: 'bars',
     child: [
       {
         show: true,
         key: 'backingImage',
         name: 'Backing Image',
-        icon: 'file-image',
       },
       {
         show: true,
         key: 'orphanedData',
         name: 'Orphan Resources',
-        icon: 'profile',
       },
       {
         show: true,
         key: 'engineimage',
         name: 'Engine Image',
-        icon: 'api',
         child: [
           {
             key: 'detail',
@@ -83,13 +71,11 @@ module.exports = [
         show: true,
         key: 'instanceManager',
         name: 'Instance Manager Image',
-        icon: 'apartment',
       },
     ],
   },
   {
     key: 'setting',
     name: 'Setting',
-    icon: 'setting',
   },
 ]

--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -76,6 +76,6 @@ module.exports = [
   },
   {
     key: 'setting',
-    name: 'Setting',
+    name: 'Settings',
   },
 ]


### PR DESCRIPTION
### What this PR does / why we need it
- Restructure the menu to make it easier for users to find pages
- Remove icons from menu
- Used consistent plural forms for clarity

### Issue
[[IMPROVEMENT] Orphaned Data should not be placed under Settings #10383](https://github.com/longhorn/longhorn/issues/10383)

### Test Result
New page structures
- Dashboard
- Nodes
- Volumes
- Recurring Jobs
- Backup and Restore
  - Backups
  - Backup Targets
  - System Backups
- Advanced
  - Backing Images
  - Orphaned Resources
  - Engine Images
  - Instance Manager Images
- Settings

**Top level menu**
<img width="1920" height="969" alt="all" src="https://github.com/user-attachments/assets/178b23ff-c5ba-4110-9092-6f8add30bc5b" />

**Backup and Snapshots**
<img width="1920" height="969" alt="backup" src="https://github.com/user-attachments/assets/3d94cb84-5633-47e9-a642-92647d00a781" />

**Advanced**
<img width="1920" height="969" alt="advanced" src="https://github.com/user-attachments/assets/9786b13c-1ef1-45b2-9176-484af4bf1a80" />


### Additional documentation or context
N/A