### PR TITLE
feat: useful error message from /v1/backuptargets is not displayed in UI

### DIFF
--- a/src/models/backup.js
+++ b/src/models/backup.js
@@ -103,7 +103,7 @@ export default {
       const resp = yield call(queryBackupTarget)
       if (resp && resp.status === 200) {
         const backupTargetAvailable = resp?.data?.some(d => d.available === true) || false
-        const backupTargetMessage = backupTargetAvailable ? '' : 'No backup target is available, please go to Setting -> Backup Target page to create one'
+        const backupTargetMessage = backupTargetAvailable ? '' : 'No backup target is available, please go to Backup Target page to create one'
         if (payload.history.location.pathname === '/backup' && !backupTargetAvailable) {
           message.error(backupTargetMessage, 3)
         } else {

--- a/src/routes/backupTarget/BackupTargetList.js
+++ b/src/routes/backupTarget/BackupTargetList.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Table } from 'antd'
+import { Table, Tooltip, Icon } from 'antd'
 import BackupTargetActions from './BackupTargetActions'
 import { pagination } from '../../utils/page'
+import style from './BackupTargetList.less'
 
 function list({ loading, dataSource, deleteBackupTarget, editBackupTarget, rowSelection, height }) {
   const columns = [
@@ -56,10 +57,17 @@ function list({ loading, dataSource, deleteBackupTarget, editBackupTarget, rowSe
       key: 'available',
       width: 90,
       sorter: (a, b) => a.available - b.available,
-      render: (text) => {
+      render: (text, record = {}) => {
         return (
-          <div className={text === true ? 'healthy' : 'error'}>
-            {text === true ? 'Available' : 'Error'}
+          <div className={style.statusWrapper}>
+            <div className={`${style.status} ${text === true ? 'healthy' : 'error'}`}>
+              {text === true ? 'Available' : 'Error'}
+            </div>
+            {record.message && (
+              <Tooltip title={record.message}>
+                <Icon type="info-circle" />
+              </Tooltip>
+            )}
           </div>
         )
       },

--- a/src/routes/backupTarget/BackupTargetList.less
+++ b/src/routes/backupTarget/BackupTargetList.less
@@ -1,0 +1,9 @@
+.statusWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.status {
+  margin-right: 5px;
+}


### PR DESCRIPTION
### What this PR does / why we need it
- Add tooltip to display more detailed messages

### Issue
[[IMPROVEMENT] useful error message from /v1/backuptargets is not displayed in UI #10428](https://github.com/longhorn/longhorn/issues/10428)

### Test Result
- Navigate to Backup Target page
- If there's an error, show an `Error` with a tooltip that displays a helpful message on hover
- If there's no error, the tooltip should NOT appear
<img width="1512" height="859" alt="Screenshot 2025-07-30 at 2 47 53 PM" src="https://github.com/user-attachments/assets/eee2178f-4cc6-4f82-bf03-5da84812433a" />
<img width="1512" height="857" alt="Screenshot 2025-07-30 at 2 49 44 PM" src="https://github.com/user-attachments/assets/0bdc189c-6a08-4f16-b87c-85734a315ce5" />

### Additional documentation or context
Sometimes the message is unreadable, this will be improved on the backend side. ([issue #11389](https://github.com/longhorn/longhorn/issues/11389))
<img width="1920" height="969" alt="Screenshot 2025-07-29 at 11 24 35 AM (2)" src="https://github.com/user-attachments/assets/aef7a0ef-a6d9-484d-8161-0e2a93cc4c81" />

