### PR TITLE
fix: sast in ui

### DIFF
--- a/src/routes/volume/UpdateSnapshotMaxSizeModal.js
+++ b/src/routes/volume/UpdateSnapshotMaxSizeModal.js
@@ -33,7 +33,7 @@ const modal = ({
 
   // Convert Units Bi to Gi
   function formatSize() {
-    if (item?.snapshotMaxSize && item?.snapshotMaxSize) {
+    if (item?.snapshotMaxSize) {
       let sizeMi = parseInt(item?.snapshotMaxSize, 10) / (1024 * 1024)
 
       return getFieldsValue().unit === 'Gi'


### PR DESCRIPTION
### What this PR does / why we need it

Сleaner code.
Result of the expression 'logical and' does not depend on the parameters:
`if (item?.snapshotMaxSize && item?.snapshotMaxSize)`

### Additional documentation or context

Svace static analyzer checks
