### PR TITLE
feat: UI supports configurable volume backup block size

### DIFF
--- a/src/models/backup.js
+++ b/src/models/backup.js
@@ -132,12 +132,18 @@ export default {
           }
         })
       }
+
       if (lastBackup) {
-        params.fromBackup = lastBackup.url
-        params.backupName = lastBackup.id
-        params.numberOfReplicas = payload.numberOfReplicas
-        params.volumeName = lastBackup.volumeName
-        params.backingImage = payload.backingImage || ''
+        const { url, id, volumeName, ...rest } = lastBackup
+
+        params = {
+          fromBackup: url,
+          backupName: id,
+          volumeName,
+          numberOfReplicas: payload.numberOfReplicas,
+          backingImage: payload.backingImage || '',
+          ...rest,
+        }
 
         yield put({ type: 'showRestoreBackupModal', payload: { currentItem: [params] } })
         yield put({ type: 'queryDiskTagsAndGetNodeTags' })
@@ -170,15 +176,21 @@ export default {
           }
         }
         if (data && data.length > 0) {
-          yield put({ type: 'showRestoreBulkBackupModal',
+          yield put({
+            type: 'showRestoreBulkBackupModal',
             payload: {
-              currentItem: data.map(d => ({
-                backupName: d.name,
-                backingImage: d.volumeBackingImageName,
-                fromBackup: d.url,
-                volumeName: d.volumeName,
-                numberOfReplicas: payload.numberOfReplicas,
-              })),
+              currentItem: data.map(d => {
+                const { name, url, volumeName, volumeBackingImageName, ...rest } = d
+
+                return {
+                  backupName: name,
+                  fromBackup: url,
+                  volumeName,
+                  backingImage: volumeBackingImageName,
+                  numberOfReplicas: payload.numberOfReplicas,
+                  ...rest,
+                }
+              }),
             },
           })
           yield put({ type: 'queryDiskTagsAndGetNodeTags' })

--- a/src/routes/backup/BackupDetail.js
+++ b/src/routes/backup/BackupDetail.js
@@ -46,16 +46,19 @@ function Backup({ backup, volume, setting, backingImage, loading, location, disp
     sorter,
     showRestoreBackup(record) {
       const currentVolume = volumeList.find((item) => record.volumeName === item.name)
+      const { id, url, volumeName, ...rest } = record
+
       dispatch({
         type: 'backup/beforeShowRestoreBackupModal',
         payload: {
           currentItem: {
-            backupName: record.id,
-            fromBackup: record.url,
+            backupName: id,
+            fromBackup: url,
             numberOfReplicas: defaultNumberOfReplicas,
-            volumeName: record.volumeName,
-            accessMode: currentVolume && currentVolume.accessMode ? currentVolume.accessMode : 'rwo',
+            volumeName,
+            accessMode: currentVolume?.accessMode || 'rwo',
             backingImage: currentBackUp.backingImageName,
+            ...rest,
           },
         },
       })

--- a/src/routes/backup/BackupList.js
+++ b/src/routes/backup/BackupList.js
@@ -192,6 +192,22 @@ class List extends React.Component {
         },
       },
       {
+        title: 'Backup Block Size',
+        dataIndex: 'blockSize',
+        key: 'blockSize',
+        width: 150,
+        sorter: (a, b) => sortTable(a, b, 'blockSize'),
+        render: (text, record) => {
+          if (record.state === 'Completed') {
+            if (String(text) === '-1') {
+              return <span className="error">Error</span>
+            }
+            return formatMib(text)
+          }
+          return null
+        }
+      },
+      {
         title: 'Backup Target',
         dataIndex: 'backupTargetName',
         key: 'backupTargetName',

--- a/src/routes/backup/RestoreBackupModal.js
+++ b/src/routes/backup/RestoreBackupModal.js
@@ -17,7 +17,7 @@ const formItemLayout = {
 }
 
 const modal = ({
-  item,
+  item = {},
   visible,
   onCancel,
   onOk,
@@ -169,7 +169,7 @@ const modal = ({
           })(<Select>
             <Option key={'enabled'} value={'enabled'}>Enabled</Option>
             <Option key={'disabled'} value={'disabled'}>Disabled</Option>
-            <Option key={'ignored'} value={'ignored'}>Ignored</Option>
+            <Option key={'ignored'} value={'ignored'}>Ignored (follow the global setting)</Option>
           </Select>)}
         </FormItem>
         <Spin spinning={tagsLoading}>
@@ -190,6 +190,19 @@ const modal = ({
             </Select>)}
           </FormItem>
         </Spin>
+        <FormItem label="Backup Block Size" hasFeedback {...formItemLayout}>
+          {getFieldDecorator('backupBlockSize', {
+            initialValue: ['0', '2097152', '16777216'].includes(String(item.blockSize))
+              ? String(item.blockSize)
+              : '0',
+          })(
+            <Select>
+              <Option key="ignored" value="0">Ignored (follow the global setting)</Option>
+              <Option key="2Mi" value="2097152">2 Mi</Option>
+              <Option key="16Mi" value="16777216">16 Mi</Option>
+            </Select>
+          )}
+        </FormItem>
       </Form>
     </ModalBlur>
   )

--- a/src/routes/volume/CreateVolume.js
+++ b/src/routes/volume/CreateVolume.js
@@ -442,6 +442,15 @@ const modal = ({
         {/* Advanced Configurations */}
         <Collapse>
           <Panel header="Advanced Configurations" key="1">
+            <FormItem label="Backup Block Size" hasFeedback {...formItemLayoutForAdvanced}>
+              {getFieldDecorator('backupBlockSize', { initialValue: '0' })(
+                <Select>
+                  <Option key={'ignored'} value={'0'}>ignored (follow the global setting)</Option>
+                  <Option key={'2Mi'} value={'2097152'}>2 Mi</Option>
+                  <Option key={'16Mi'} value={'16777216'}>16 Mi</Option>
+                </Select>
+              )}
+            </FormItem>
             <FormItem label="Snapshot Data Integrity" hasFeedback {...formItemLayoutForAdvanced}>
               {getFieldDecorator('snapshotDataIntegrity', {
                 initialValue: 'ignored',

--- a/src/routes/volume/detail/VolumeInfo.js
+++ b/src/routes/volume/detail/VolumeInfo.js
@@ -254,6 +254,10 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
         {selectedVolume.backupTargetName || ''}
       </div>
       <div className={styles.row}>
+        <span className={styles.label}> Backup Block Size:</span>
+        {formatMib(selectedVolume.backupBlockSize)}
+      </div>
+      <div className={styles.row}>
         <span className={styles.label}> Data Engine:</span>
         {selectedVolume.dataEngine}
       </div>


### PR DESCRIPTION
### What this PR does / why we need it
- Provide backup block size options (Ignore, 2 MiB, or 16 MiB) when creating a new volume or restoring from a backup
- Show `Backup Block Size` in volume detail page

### Issue
[[FEATURE] UI supports configurable volume backup block size #11351](https://github.com/longhorn/longhorn/issues/11351)

### Test Result
- Create a volume and verify that the `Backup Block Size` options are available in the `Advanced Configuration`
- Navigate to the volume detail page and confirm that `Backup Block Size` is displayed in the `Volume Detail`
- Create a backup and verify that `Backup Block Size` is displayed in the backup list page
- Restore the backup and confirm that `Backup Block Size` options are available in the restore modal
- Verify the same behavior for bulk restore actions

Uploading Screen Recording 2025-08-27 at 12.14.10 PM.mov…

- If the API response includes `blockSize: '-1'`, the list should display `Error`
<img width="1920" height="1080" alt="Screenshot 2025-08-27 at 10 55 04 AM (2)" src="https://github.com/user-attachments/assets/2bfcc70a-01d6-44ca-a626-a1c07755eb79" />

### Additional documentation or context
N/A
