### PR TITLE
fix: UI supports configurable volume backup block size

### DIFF
--- a/src/models/backup.js
+++ b/src/models/backup.js
@@ -302,6 +302,7 @@ export default {
           lastBackupUrl: lastBackup.url,
           size: lastBackup.volumeSize,
           backingImage: lastBackup.volumeBackingImageName,
+          blockSize: lastBackup.blockSize
         }
       })
       // For DR Volume
@@ -442,7 +443,7 @@ export default {
       return { ...state, showBackuplabelsModalVisible: false, createVolumeStandModalKey: Math.random() }
     },
     initModalUrl(state, action) {
-      return { ...state, lastBackupUrl: action.found.url, volumeName: action.payload.name, size: action.found.volumeSize }
+      return { ...state, lastBackupUrl: action.found.url, volumeName: action.payload.name, size: action.found.volumeSize, blockSize: action.found.blockSize }
     },
     initBulkCreateModalUrl(state, action) {
       return { ...state, backupVolumesForBulkCreate: action.volumes }

--- a/src/routes/backup/BackupDetail.js
+++ b/src/routes/backup/BackupDetail.js
@@ -14,7 +14,7 @@ import WorkloadDetailModal from '../volume/WorkloadDetailModal'
 const { confirm } = Modal
 
 function Backup({ backup, volume, setting, backingImage, loading, location, dispatch }) {
-  const { backupVolumes, backupData, restoreBackupModalVisible, restoreBackupModalKey, currentItem, sorter, showBackupLabelsModalKey, backupLabel, showBackuplabelsModalVisible, createVolumeStandModalKey, createVolumeStandModalVisible, baseImage, size, lastBackupUrl, workloadDetailModalVisible, workloadDetailModalItem, workloadDetailModalKey, previousChecked, tagsLoading, nodeTags, diskTags } = backup
+  const { backupVolumes, backupData, restoreBackupModalVisible, restoreBackupModalKey, currentItem, sorter, showBackupLabelsModalKey, backupLabel, showBackuplabelsModalVisible, createVolumeStandModalKey, createVolumeStandModalVisible, baseImage, size, lastBackupUrl, blockSize, workloadDetailModalVisible, workloadDetailModalItem, workloadDetailModalKey, previousChecked, tagsLoading, nodeTags, diskTags } = backup
 
   const volumeList = volume.data
   const settings = setting.data
@@ -156,6 +156,7 @@ function Backup({ backup, volume, setting, backingImage, loading, location, disp
       baseImage,
       fromBackup: lastBackupUrl,
       backingImage: currentBackUp ? currentBackUp.backingImageName : '',
+      blockSize
     },
     nodeTags,
     diskTags,

--- a/src/routes/backup/BackupVolume.js
+++ b/src/routes/backup/BackupVolume.js
@@ -33,7 +33,7 @@ function BackupVolume({ backup, loading, setting, backingImage, dispatch, locati
   location.search = location.search || ''
   // currentItem || currentBackupVolume. The currentItem was a wrong decision at the beginning of the design. It was originally to simplify the transfer of attributes without complete assignment.
   // When backup supports ws, currentItem will be refactored to currentBackupVolume
-  const { backupVolumes, sorter, backupFilterKey, currentItem, restoreBackupModalKey, createVolumeStandModalKey, bulkCreateVolumeStandModalKey, createVolumeStandModalVisible, bulkCreateVolumeStandModalVisible, lastBackupUrl, size, restoreBackupModalVisible, selectedRows, previousChecked, tagsLoading, nodeTags, diskTags, volumeName, backupVolumesForBulkCreate, workloadDetailModalVisible, WorkloadDetailModalKey, workloadDetailModalItem, currentBackupVolume } = backup
+  const { backupVolumes, sorter, backupFilterKey, currentItem, restoreBackupModalKey, createVolumeStandModalKey, bulkCreateVolumeStandModalKey, createVolumeStandModalVisible, bulkCreateVolumeStandModalVisible, lastBackupUrl, blockSize, size, restoreBackupModalVisible, selectedRows, previousChecked, tagsLoading, nodeTags, diskTags, volumeName, backupVolumesForBulkCreate, workloadDetailModalVisible, WorkloadDetailModalKey, workloadDetailModalItem, currentBackupVolume } = backup
   const { field, value } = queryString.parse(location.search)
   const backupVolumesData = filterBackupVolumes(backupVolumes, field, value)
   const settings = setting.data
@@ -264,6 +264,7 @@ function BackupVolume({ backup, loading, setting, backingImage, dispatch, locati
       fromBackup: lastBackupUrl,
       name: volumeName,
       backingImage: currentBackupVolume?.backingImageName || '',
+      blockSize
     },
     visible: createVolumeStandModalVisible,
     nodeTags,
@@ -294,6 +295,7 @@ function BackupVolume({ backup, loading, setting, backingImage, dispatch, locati
       fromBackup: item.lastBackupUrl,
       volumeName: item.volumeName,
       backingImage: item.backingImage,
+      blockSize: item.blockSize,
     })),
     numberOfReplicas: defaultNumberOfReplicas,
     visible: bulkCreateVolumeStandModalVisible,

--- a/src/routes/backup/BulkCreateStandbyVolumeModal.js
+++ b/src/routes/backup/BulkCreateStandbyVolumeModal.js
@@ -54,6 +54,7 @@ const modal = ({
     encrypted: false,
     nodeSelector: [],
     diskSelector: [],
+    backupBlockSize: i.blockSize || '0'
   }))
   const [currentTab, setCurrentTab] = useState(0)
   const [drVolumeConfigs, setDrVolumeConfigs] = useState(initConfigs)
@@ -301,6 +302,19 @@ const modal = ({
             </Select>)}
           </FormItem>
         </Spin>
+        <FormItem label="Backup Block Size" hasFeedback {...formItemLayout}>
+          {getFieldDecorator('backupBlockSize', {
+            initialValue: ['0', '2097152', '16777216'].includes(String(item.backupBlockSize))
+              ? String(item.backupBlockSize)
+              : '0',
+          })(
+            <Select disabled>
+              <Option key="ignored" value="0">Ignored (follow the global setting)</Option>
+              <Option key="2Mi" value="2097152">2 Mi</Option>
+              <Option key="16Mi" value="16777216">16 Mi</Option>
+            </Select>
+          )}
+        </FormItem>
       </Form>
     </ModalBlur>
   )

--- a/src/routes/backup/BulkRestoreBackupModal.js
+++ b/src/routes/backup/BulkRestoreBackupModal.js
@@ -305,7 +305,7 @@ const modal = ({
         </Spin>
         <FormItem label="Backup Block Size" hasFeedback {...formItemLayout}>
           {getFieldDecorator('backupBlockSize', {
-            initialValue: ['0', '2097152', '16777216'].includes(String(item.blockSize))
+            initialValue: ['0', '2097152', '16777216'].includes(String(item.backupBlockSize))
               ? String(item.backupBlockSize)
               : '0',
           })(

--- a/src/routes/backup/CreateStandbyVolumeModal.js
+++ b/src/routes/backup/CreateStandbyVolumeModal.js
@@ -18,7 +18,7 @@ const formItemLayout = {
 }
 
 const modal = ({
-  item,
+  item = {},
   visible,
   onCancel,
   onOk,
@@ -203,6 +203,19 @@ const modal = ({
             </Select>)}
           </FormItem>
         </Spin>
+        <FormItem label="Backup Block Size" hasFeedback {...formItemLayout}>
+          {getFieldDecorator('backupBlockSize', {
+            initialValue: ['0', '2097152', '16777216'].includes(String(item.blockSize))
+              ? String(item.blockSize)
+              : '0',
+          })(
+            <Select disabled>
+              <Option key="ignored" value="0">Ignored (follow the global setting)</Option>
+              <Option key="2Mi" value="2097152">2 Mi</Option>
+              <Option key="16Mi" value="16777216">16 Mi</Option>
+            </Select>
+          )}
+        </FormItem>
         <div style={{ display: 'none' }}>
           <FormItem label="Backup Url" hasFeedback {...formItemLayout}>
             {getFieldDecorator('fromBackup', {


### PR DESCRIPTION
### What this PR does / why we need it
- Add `Backup Block Size` for DR volume

### Issue
[[FEATURE] UI supports configurable volume backup block size #11351](https://github.com/longhorn/longhorn/issues/11351)

### Test Result
- Navigate to the backup page and click `Create Disaster Recovery Volume`
- Confirm that the `Backup Block Size` is read-only in the modal and its value matches the source volume (latest backup)

https://github.com/user-attachments/assets/b5ec6ced-55cb-45b1-b499-8b82bacc9b4d

### Additional documentation or context
Related PR: https://github.com/longhorn/longhorn-ui/pull/948