### PR TITLE
fix: incorrect route for backup page

### DIFF
--- a/src/routes/volume/detail/index.js
+++ b/src/routes/volume/detail/index.js
@@ -310,10 +310,10 @@ function VolumeDetail({ snapshotModal, dispatch, backup, engineimage, eventlog, 
     },
     showBackups(record) {
       dispatch(routerRedux.push({
-        pathname: `/backup/${record.name}`,
+        pathname: '/backup',
         search: queryString.stringify({
           field: 'volumeName',
-          keyword: record.name,
+          value: record.name,
         }),
       }))
     },

--- a/src/routes/volume/index.js
+++ b/src/routes/volume/index.js
@@ -383,11 +383,11 @@ class Volume extends React.Component {
       },
       showBackups(record) {
         dispatch(routerRedux.push({
-          pathname: `/backup/${record.name}`,
+          pathname: '/backup',
           search: queryString.stringify({
             ...queryString.parse(location.search),
             field: 'volumeName',
-            keyword: record.name,
+            value: record.name,
           }),
         }))
       },


### PR DESCRIPTION
### What this PR does / why we need it
- Redirect to backup volume page with filter

### Issue
[[BUG] [UI] [v1.9.2-rc2] Unable to Retrieve Volume's Backup List in the Operation #11841](https://github.com/longhorn/longhorn/issues/11841)

### Test Result
https://github.com/user-attachments/assets/2734b674-01f7-4aa6-8000-0672a0a10dd0

### Additional documentation or context
N/A
