### PR TITLE
fix: conditionally enable IPv6 listening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM registry.suse.com/bci/bci-base:15.7
 RUN zypper -n ref && \
     zypper update -y
 
-RUN zypper -n install curl libxml2 bash gettext shadow nginx && \
+RUN zypper -n install curl libxml2 bash gettext shadow nginx iproute2 && \
     rm -f /bin/sh && ln -s /bin/bash /bin/sh
 
 RUN mkdir -p web/dist
@@ -34,4 +34,6 @@ RUN mkdir -p /var/config/ && touch /var/run/nginx.pid && chown -R 499 /var/confi
 # Use the uid of the default user (nginx) from the installed nginx package
 USER 499
 
-CMD ["/bin/bash", "-c", "mkdir -p /var/config/nginx/ && cp -r /etc/nginx/* /var/config/nginx/; envsubst '${LONGHORN_MANAGER_IP},${LONGHORN_UI_PORT}' < /etc/nginx/nginx.conf.template > /var/config/nginx/nginx.conf && nginx -c /var/config/nginx/nginx.conf -g 'daemon off;'"]
+COPY --chmod=755 scripts/start-nginx.sh /usr/local/bin/start-nginx.sh
+
+CMD ["/usr/local/bin/start-nginx.sh"]

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -10,7 +10,7 @@ http {
         include /etc/nginx/mime.types;
 
         listen ${LONGHORN_UI_PORT};       # IPv4
-        listen [::]:${LONGHORN_UI_PORT};  # IPv6
+        ${IPV6_LISTEN}
 
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/scripts/start-nginx.sh
+++ b/scripts/start-nginx.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+TEMPLATE=/etc/nginx/nginx.conf.template
+CONFIG_DIR=/var/config/nginx
+FINAL_CONF=$CONFIG_DIR/nginx.conf
+
+mkdir -p $CONFIG_DIR
+cp -r /etc/nginx/* $CONFIG_DIR
+
+# Detect IPv6 only
+if ip -6 addr show scope global | grep -q inet6; then
+    echo "IPv6 detected, enabling IPv6 listen on port ${LONGHORN_UI_PORT}"
+    export IPV6_LISTEN="listen [::]:${LONGHORN_UI_PORT};"
+else
+    echo "No IPv6 address detected, running in IPv4-only mode..."
+    export IPV6_LISTEN=""
+fi
+
+# Generate Nginx config dynamically
+envsubst '${LONGHORN_MANAGER_IP},${LONGHORN_UI_PORT},${IPV6_LISTEN}' \
+    < $TEMPLATE > $FINAL_CONF
+
+# Start Nginx
+nginx -c $FINAL_CONF -g 'daemon off;'


### PR DESCRIPTION
### What this PR does / why we need it

Conditionally enables IPv6 listening in the Longhorn UI Nginx container. This ensures the container works correctly on both IPv4-only and dual-stack networks.

### Issue

longhorn/longhorn#11869

### Test Result

### Additional documentation or context
