### PR TITLE
fix: Update dashboard schedulable storage metrics

### DIFF
--- a/src/routes/dashboard/components/resourceOverview.js
+++ b/src/routes/dashboard/components/resourceOverview.js
@@ -90,7 +90,7 @@ class ResourceOverview extends React.Component {
       const result = host.data.filter(n => n.allowScheduling === true).reduce((total, currentNode) => {
         return total + Object.values(currentNode.disks).filter(d => d.allowScheduling === true).reduce((availabeSpace, currentDisk) => {
           if (currentDisk.diskType === blockDiskType || !currentDisk.diskType) {
-            return availabeSpace + (currentDisk.storageAvailable - currentDisk.storageReserved)
+            return availabeSpace + currentDisk.storageAvailable
           }
           return availabeSpace
         }, 0)
@@ -103,7 +103,7 @@ class ResourceOverview extends React.Component {
       return host.data.filter(n => n.allowScheduling === true).reduce((total, currentNode) => {
         return total + Object.values(currentNode.disks).filter(d => d.allowScheduling === true).reduce((usedSpace, currentDisk) => {
           if (currentDisk.diskType === blockDiskType || !currentDisk.diskType) {
-            return usedSpace + (currentDisk.storageMaximum - currentDisk.storageAvailable)
+            return usedSpace + (currentDisk.storageMaximum - currentDisk.storageReserved - currentDisk.storageAvailable)
           }
           return usedSpace
         }, 0)


### PR DESCRIPTION
### What this PR does / why we need it
This update uses storageScheduled to represent allocated (scheduled) capacity and storageAvailable to represent schedulable capacity, avoiding double counting and negative values caused by subtracting reserved space. The result is a more accurate and predictable view of how much storage is actually allocated by Longhorn versus what remains available for scheduling.

Issue :

https://github.com/longhorn/longhorn/issues/12633

