### PR TITLE
feat: add link to release notes

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -58,6 +58,11 @@ function Footer({ app, host, volume, setting, engineimage, eventlog, backingImag
     )
   }
 
+  let releaseHref = 'https://github.com/longhorn/longhorn/releases/'
+  if (currentVersion !== 'dev') {
+    releaseHref += `tag/${currentVersion}`
+  }
+
   const createBundlesrops = {
     item: {},
     visible: bundlesropsVisible,
@@ -113,7 +118,7 @@ function Footer({ app, host, volume, setting, engineimage, eventlog, backingImag
       <Row type="flex" justify="space-between">
         <Col>
           {upgrade}
-          <a>{currentVersion}</a>
+          <a target="blank" href={releaseHref}>{currentVersion}</a>
           <a target="blank" href="https://longhorn.io/docs">Documentation</a>
           <a target="blank" onClick={showBundlesModel}>Generate Support Bundle</a>
           <a target="blank" href={issueHref}>File an Issue</a>


### PR DESCRIPTION
### What this PR does / why we need it

Currently the version number in the footer is a link without any href. A user can believe that clicking the item will take them somewhere based on behaviour of all other footer items.  This PR updates the link removes the confusion by directing the user to the release notes of the installed version or falling back to the list of releases for development versions. 
