### PR TITLE
fix: pin axios to 1.13.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@babel/runtime-corejs2": "^7.0.0",
         "antd": "3.26.20",
-        "axios": "^1.7.4",
+        "axios": "1.13.6",
         "classnames": "^2.2.5",
         "cron-parser": "^2.11.0",
         "dva": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@babel/runtime-corejs2": "^7.0.0",
     "antd": "3.26.20",
-    "axios": "^1.7.4",
+    "axios": "1.13.6",
     "classnames": "^2.2.5",
     "cron-parser": "^2.11.0",
     "dva": "^2.4.1",


### PR DESCRIPTION
### What this PR does / why we need it
fix: pin axios to 1.13.6.


### Issue

### Test Result

### Additional documentation or context
