### PR TITLE
feat: add Backup Target to volume list custom column options

### DIFF
--- a/src/routes/volume/CustomColumn.js
+++ b/src/routes/volume/CustomColumn.js
@@ -84,6 +84,10 @@ const modal = ({
       label: 'Last Backup At',
     },
     {
+      value: 'backupTargetName',
+      label: 'Backup Target',
+    },
+    {
       value: 'replicas',
       label: 'Replicas',
     },

--- a/src/routes/volume/VolumeList.js
+++ b/src/routes/volume/VolumeList.js
@@ -538,6 +538,20 @@ function list({
       },
     },
     {
+      title: 'Backup Target',
+      dataIndex: 'backupTargetName',
+      key: 'backupTargetName',
+      width: 180,
+      sorter: (a, b) => sortTable(a, b, 'backupTargetName'),
+      render: (text) => {
+        return (
+          <div>
+            {text || ''}
+          </div>
+        )
+      },
+    },
+    {
       title: 'Operation',
       key: 'operation',
       width: 110,

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -13,6 +13,56 @@ var FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const endpoint = process.env.LONGHORN_MANAGER_IP || 'http://54.223.25.181:9500/';
 const versionText = require('fs').readFileSync('./version', 'utf8');
 const longhornVersion = versionText ? versionText.trim().substring(1).split('-')[0]: '1.7.0';
+const ignoredProxyErrorCodes = new Set(['ECONNRESET', 'EPIPE', 'ERR_STREAM_DESTROYED']);
+
+function isIgnoredProxyError(error) {
+  return Boolean(error && ignoredProxyErrorCodes.has(error.code));
+}
+
+function handleProxyError(error, proxyPath, res) {
+  if (!error) {
+    return;
+  }
+
+  if (isIgnoredProxyError(error)) {
+    console.warn(`[dev-server proxy] ${error.code} while proxying ${proxyPath} to ${endpoint}`);
+  } else {
+    console.error(error);
+  }
+
+  if (!res) {
+    return;
+  }
+
+  if (typeof res.writeHead === 'function' && !res.headersSent) {
+    res.writeHead(502, { 'Content-Type': 'text/plain' });
+    res.end('Proxy error');
+    return;
+  }
+
+  if (typeof res.destroy === 'function') {
+    res.destroy();
+  }
+}
+
+function attachSocketErrorHandler(socket, proxyPath) {
+  if (!socket || socket.__longhornErrorHandlerAttached) {
+    return;
+  }
+
+  socket.__longhornErrorHandlerAttached = true;
+  socket.on('error', (error) => handleProxyError(error, proxyPath));
+}
+
+function createProxyOptions(proxyPath) {
+  return {
+    target: endpoint,
+    changeOrigin: true,
+    onError(error, req, res) {
+      handleProxyError(error, req && req.url ? req.url : proxyPath, res);
+    },
+  };
+}
 
 module.exports = {
   entry: path.resolve(__dirname, "src", "index.js"),
@@ -38,15 +88,17 @@ module.exports = {
       proxyTimeout: 10 * 60 * 1000,
       timeout: 10 * 60 * 1000,
       "/v1/ws/**": {
-        "target": endpoint,
-        "changeOrigin": true,
-        "ws": true,
-        "secure": false
+        ...createProxyOptions('/v1/ws/**'),
+        ws: true,
+        secure: false,
+        onProxyReqWs(proxyReq, req, socket) {
+          attachSocketErrorHandler(socket, req && req.url ? req.url : '/v1/ws/**');
+        },
+        onOpen(proxySocket) {
+          attachSocketErrorHandler(proxySocket, '/v1/ws/**');
+        },
       },
-      "/v1/": {
-        "target": endpoint,
-        "changeOrigin": true
-      },
+      "/v1/": createProxyOptions('/v1/'),
     },
     watchOptions: {
       ignored: /node_modules/,


### PR DESCRIPTION
### What this PR does / why we need it
- Add Backup Target as an available option in the Custom Column selector on the Volumes list page

### Issue
[[IMPROVEMENT] Add Backup Target to volume list custom column options #12619](https://github.com/longhorn/longhorn/issues/12619)

### Test Result
- Navigate to the Volume List page
- Click `Custom Volume`
- Verify that the `Backup Target` option is visible
- Select `Backup Target`, confirm that `Backup Target` appears as a column in the volume list table

https://github.com/user-attachments/assets/17cf4614-c379-411e-8053-1b02cb0fa6c9

### Additional documentation or context
N/A
