### PR TITLE
feat: TooManySnapshots volume condition uses a hard-coded threshold despite configurable snapshot max count

### DIFF
--- a/src/routes/volume/detail/ConditionTooltip.js
+++ b/src/routes/volume/detail/ConditionTooltip.js
@@ -9,10 +9,19 @@ const toolTipContent = (field, prefix, value = '') => {
   return (<div style={{ marginBottom: 5 }}>{prefix}: {text}</div>)
 }
 
-function ConditionTooltip({ selectedVolume, conditionKey }) {
+const parsePositiveNumber = (value) => {
+  const num = Number(value)
+  return Number.isFinite(num) && num > 0 ? num : null
+}
+
+function ConditionTooltip({ selectedVolume, conditionKey, snapshotWarningThreshold }) {
   let icon = <Icon style={{ marginRight: 5 }} type="exclamation-circle" />
   let conditionClassName = ''
   const { type, lastProbeTime, lastTransitionTime, message, reason, status } = selectedVolume.conditions[conditionKey] || {}
+  const computedThreshold = Math.min(
+    parsePositiveNumber(snapshotWarningThreshold),
+    parsePositiveNumber(selectedVolume.snapshotMaxCount)
+  )
   let title = selectedVolume.conditions[conditionKey] ? (
     <div>
       {toolTipContent(type, 'Name', type)}
@@ -31,7 +40,7 @@ function ConditionTooltip({ selectedVolume, conditionKey }) {
           <div>
             {toolTipContent(type, 'Name', type) }
             {toolTipContent(lastTransitionTime, 'Last Transition Time', lastTransitionTime)}
-            {toolTipContent(status, 'Status', 'The snapshot number threshold (100) has not been exceeded')}
+            {toolTipContent(status, 'Status', `The snapshot number threshold (${computedThreshold}) has not been exceeded`)}
           </div>
         )
       } else {
@@ -83,6 +92,7 @@ function ConditionTooltip({ selectedVolume, conditionKey }) {
 ConditionTooltip.propTypes = {
   selectedVolume: PropTypes.object,
   conditionKey: PropTypes.string,
+  snapshotWarningThreshold: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 }
 
 export default ConditionTooltip

--- a/src/routes/volume/detail/VolumeInfo.js
+++ b/src/routes/volume/detail/VolumeInfo.js
@@ -18,7 +18,7 @@ import ConditionTooltip from './ConditionTooltip'
 import { isVolumeImageUpgradable, isVolumeReplicaNotRedundancy, isVolumeRelicaLimited } from '../../../utils/filter'
 
 
-function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, currentBackingImage }) {
+function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, currentBackingImage, snapshotWarningThreshold }) {
   let errorMsg = null
   const state = snapshotModalState
 
@@ -248,6 +248,7 @@ function VolumeInfo({ selectedVolume, snapshotModalState, engineImages, hosts, c
                     key={key}
                     selectedVolume={selectedVolume}
                     conditionKey={key}
+                    snapshotWarningThreshold={snapshotWarningThreshold}
                   />
                 ))}
           </div>
@@ -467,6 +468,7 @@ VolumeInfo.propTypes = {
   snapshotModal: PropTypes.object,
   snapshotModalState: PropTypes.bool,
   engineImages: PropTypes.array,
+  snapshotWarningThreshold: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   currentBackingImage: PropTypes.object,
   hosts: PropTypes.array,
 }

--- a/src/routes/volume/detail/index.js
+++ b/src/routes/volume/detail/index.js
@@ -198,6 +198,7 @@ function VolumeDetail({
   const settings = setting.data
   const defaultDataLocalitySetting = settings.find(s => s.id === 'default-data-locality')
   const defaultSnapshotDataIntegritySetting = settings.find(s => s.id === 'snapshot-data-integrity')
+  const snapshotWarningThresholdSetting = settings.find(s => s.id === 'snapshot-count-warning-threshold')
   const engineUpgradePerNodeLimit = settings.find(s => s.id === 'concurrent-automatic-engine-upgrade-per-node-limit')
 
   const defaultDataLocalityOption = defaultDataLocalitySetting?.definition?.options || []
@@ -250,6 +251,7 @@ function VolumeDetail({
     backupStatus,
     snapshotModalState,
     engineImages,
+    snapshotWarningThreshold: snapshotWarningThresholdSetting?.value,
     currentBackingImage,
     hosts,
     clearBackupStatus() {


### PR DESCRIPTION
### What this PR does / why we need it
- Use `min(snapshot-warning-threshold, v.Spec.SnapshotMaxCount)` as the snapshot count threshold

### Issue
[[UI][IMPROVEMENT] TooManySnapshots volume condition uses a hard-coded threshold despite configurable snapshot max count #12922](https://github.com/longhorn/longhorn/issues/12922)

### Test Result
https://github.com/user-attachments/assets/964005ac-a5b4-4225-8f1b-bf8ba713bff2

### Additional documentation or context
N/A