### PR TITLE
fix: UI does not update v2 backup state from Error to Completed

### DIFF
--- a/src/components/Snapshot/Snapshot.js
+++ b/src/components/Snapshot/Snapshot.js
@@ -149,7 +149,7 @@ function SnapshotIcon(props, snapshotProps) {
     backgroundColor = '#cccccc'
   }
 
-  if (backupStatusHasError) {
+  if (backupStatusHasError && !backupStatusObject.isCompleted) {
     backgroundColor = '#F15354'
   }
 
@@ -177,7 +177,7 @@ function SnapshotIcon(props, snapshotProps) {
            {backupStatusObject.replicas && <p className="snapshot-created" style={{ wordBreak: 'break-all' }}>Replicas: {backupStatusObject.replicas}</p>}
            {backupStatusObject.replicas && <p className="snapshot-created" style={{ wordBreak: 'break-all' }}>Backups: {backupStatusObject.backupIds}</p>}
             {/* <p className="snapshot-created">Backup URL: {backupStatusObject.backupURL}</p> */}
-            {backupStatusErrorMsg}</div> : ''
+            {backupStatusObject.isCompleted ? '' : backupStatusErrorMsg}</div> : ''
         }
       </div>}>
         <div>

--- a/src/utils/formatter.js
+++ b/src/utils/formatter.js
@@ -90,11 +90,12 @@ export function formatSnapshot(selectVolume, snapshot) {
         if (ele.error) {
           backupStatusErrorMsg.push({ replica: ele.replica, error: ele.error })
         }
-        total += ele.progress
+        total += ele.state === 'Completed' ? 100 : ele.progress
       })
       backupStatusObject = {}
       backupStatusObject.backupError = backupStatusErrorMsg
       backupStatusObject.progress = Math.floor(total / backupStatusObjectList.length)
+      backupStatusObject.isCompleted = backupStatusObjectList.every(ele => ele.state === 'Completed')
       backupStatusObject.snapshot = snapshot.name
       backupStatusObject.replicas = backupStatusObjectList.filter(item => item.replica).map(item => item.replica).join(', ')
       backupStatusObject.backupIds = backupStatusObjectList.filter(item => item.id).map(item => item.id).join(',')


### PR DESCRIPTION
### What this PR does / why we need it
- Display `Successful` first when the state is `Completed`

### Issue
[[BUG] UI does not update v2 backup state from Error to Completed #12842](https://github.com/longhorn/longhorn/issues/12842)

### Test Result
<img width="1512" height="866" alt="Screenshot 2026-05-11 at 5 10 07 PM" src="https://github.com/user-attachments/assets/362be761-51b3-4282-b746-c672896f99fc" />

### Additional documentation or context
N/A
