### PR TITLE
feat: misleading storage values

### DIFF
--- a/src/routes/dashboard/components/resourceOverview.js
+++ b/src/routes/dashboard/components/resourceOverview.js
@@ -85,29 +85,30 @@ class ResourceOverview extends React.Component {
       }, 0)
     }
     // Available (green)
-    // a. AvailableForSchedulingStorage = sum(enabledNodes.enabledDisks.AvailableStorage - enabledNodes.enabledDisks.ReservedStorage)
+    // a. AvailableForSchedulingStorage = sum(enabledNodes.enabledDisks.AvailableStorage)
     const computeSchedulableSpace = (blockDiskType) => {
       const result = host.data.filter(n => n.allowScheduling === true).reduce((total, currentNode) => {
         return total + Object.values(currentNode.disks).filter(d => d.allowScheduling === true).reduce((availabeSpace, currentDisk) => {
           if (currentDisk.diskType === blockDiskType || !currentDisk.diskType) {
-            return availabeSpace + (currentDisk.storageAvailable - currentDisk.storageReserved)
+            return availabeSpace + currentDisk.storageAvailable
           }
           return availabeSpace
         }, 0)
       }, 0)
-      return result < 0 ? 0 : result
+      return Math.max(0, result)
     }
     // Used (blue)
-    // a. UsedStorage = sum(enabledNodes.enabledDisk.MaximumStorage - enabledNodes.enabledDisks.AvailableStorage)
+    // a. UsedStorage = sum(enabledNodes.enabledDisk.ScheduledStorage)
     const computeUsedSpace = (blockDiskType) => {
-      return host.data.filter(n => n.allowScheduling === true).reduce((total, currentNode) => {
+      const result = host.data.filter(n => n.allowScheduling === true).reduce((total, currentNode) => {
         return total + Object.values(currentNode.disks).filter(d => d.allowScheduling === true).reduce((usedSpace, currentDisk) => {
           if (currentDisk.diskType === blockDiskType || !currentDisk.diskType) {
-            return usedSpace + (currentDisk.storageMaximum - currentDisk.storageAvailable)
+            return usedSpace + (currentDisk.storageScheduled || 0)
           }
           return usedSpace
         }, 0)
       }, 0)
+      return Math.max(0, result)
     }
     const storageSpaceInfo = {
       totalSpace: computeTotalSpace('filesystem'),


### PR DESCRIPTION
### What this PR does / why we need it
- Use `storageScheduled` to represent allocated (scheduled) capacity
- Use `storageAvailable` directly to represent schedulable capacity

### Issue
[[IMPROVEMENT] Misleading storage values #12633](https://github.com/longhorn/longhorn/issues/12633)

### Test Result
 **Example calculation:**
  | Node | storageMaximum | storageReserved | storageAvailable | storageScheduled |
  |------|----------------|-----------------|------------------|------------------|
  | A    | 40 Gi          | 12 Gi           | 28 Gi            | 4 Gi      |
  | B    | 40 Gi          | 0 Gi            | 16 Gi            | 6 Gi     |
  | C    | 40 Gi          | 10 Gi           | 13 Gi            | 7 Gi |

Before this fix:
 - Schedulable = storageAvailable - storageReserved)
   - Schedulable = (28-12) + (16-0) + (13-10) = **35 Gi** ❌
 - Used: storageMaximum - storageAvailable
   - Used = (40-28) + (40-16) + (40-13) = **63 Gi** ❌
   
<img width="1512" height="866" alt="Screenshot 2026-05-19 at 7 02 43 PM" src="https://github.com/user-attachments/assets/5b905c35-dbc7-4a4c-9cc4-60d55ad69302" />

After this fix:
- Schedulable = storageAvailable
  - Schedulable = 28 + 16 + 13 = **57 Gi** ✅
- Used = storageScheduled
  - Used = 4 + 6 + 7 = **17 Gi** ✅
  
<img width="1512" height="863" alt="Screenshot 2026-05-19 at 7 03 13 PM" src="https://github.com/user-attachments/assets/0f962704-115e-4c14-8cf0-990921ce0824" />
 
### Additional documentation or context
N/A