### PR TITLE
fix: removed extra v from current version-release

### DIFF
--- a/src/components/Layout/Footer.js
+++ b/src/components/Layout/Footer.js
@@ -108,7 +108,7 @@ function Footer({ app, host, volume, setting, engineimage, eventlog, backingImag
     },
   }
 
-  const versionHref = currentVersion === 'dev' ? 'https://github.com/longhorn/longhorn/releases' : `https://github.com/longhorn/longhorn/releases/tag/v${currentVersion}`
+  const versionHref = currentVersion === 'dev' ? 'https://github.com/longhorn/longhorn/releases' : `https://github.com/longhorn/longhorn/releases/tag/${currentVersion}`
 
   return (
     <div className={styles.footer}>


### PR DESCRIPTION
### What this PR does / why we need it

Fixes a malformed GitHub release link in the bottom-right footer of the WebGUI.

### Issue

[Related Issue](https://github.com/longhorn/longhorn/issues/13352)

### Test Result

Verified locally.

### Additional documentation or context

N/A
