### PR TITLE
fix(ui): run nginx as container PID 1

### DIFF
--- a/scripts/start-nginx.sh
+++ b/scripts/start-nginx.sh
@@ -23,4 +23,4 @@ envsubst '${LONGHORN_MANAGER_IP},${LONGHORN_UI_PORT},${IPV6_LISTEN}' \
     < $TEMPLATE > $FINAL_CONF
 
 # Start Nginx
-nginx -c $FINAL_CONF -g 'daemon off;'
+exec nginx -c $FINAL_CONF -g 'daemon off;'


### PR DESCRIPTION
### What this PR does / why we need it
This PR starts nginx using `exec` in `start-nginx.sh`.

Currently, the startup script remains PID 1 while nginx runs as a child process. This prevents nginx from receiving the container termination signal and causes the Longhorn UI container to wait until the termination timeout is reached.

Using exec replaces the shell process with nginx, making nginx PID 1 and allowing it to handle SIGTERM directly.
### Issue
https://github.com/longhorn/longhorn/issues/13680
### Test Result
#### Before change
The startup script is PID 1:
```
~/longhorn-ui$ podman exec longhorn-ui-baseline   bash -c 'echo -n "PID 1: "; tr "\0" " " < /proc/1
PID 1: /bin/bash /usr/local/bin/start-nginx.sh
```
The container does not terminate on SIGTERM and reaches the configured timeout:
```
~/longhorn-ui$ time podman stop --time 30 longhorn-ui-baseline
WARN[0030] StopSignal SIGTERM failed to stop container longhorn-ui-baseline in 30 seconds, resorting to SIGKILL
longhorn-ui

real    0m30.491s
user    0m0.486s
sys     0m0.767s
```

#### After fixes:
nginx is PID 1:
```
~/longhorn-ui$ podman exec longhorn-ui-exec   bash -c 'echo -n "PID 1: "; tr "\0" " " < /proc/1/cmdline; echo'
PID 1: nginx: master process nginx -c /var/config/nginx/nginx.conf -g daemon off;
```
The container terminates shortly after receiving SIGTERM:
```
~/longhorn-ui-fixed~$ time podman stop --time 30 longhorn-ui-exec
longhorn-ui-exec

real    0m0.532s
user    0m0.048s
sys     0m0.118s
```



### Additional documentation or context
