### PR TITLE
feat: truncate attached-to pod list in volume table

### DIFF
--- a/src/routes/volume/VolumeList.js
+++ b/src/routes/volume/VolumeList.js
@@ -420,14 +420,17 @@ function list({
       sorter: (a, b) => sortTable(a, b, 'WorkloadName'),
       render: (text, record) => {
         const title = text.lastPodRefAt ? <div><div>Last time used: {formatDate(text.lastPodRefAt)}</div></div> : ''
-        const ele = text.podList.length ? text.podList.map((item, index) => {
-          return <div key={index}>{item.podName}</div>
-        }) : ''
+        const maxDisplayPods = 3
+        const podsToDisplay = text.podList.slice(0, maxDisplayPods)
+        const ele = podsToDisplay.length ? podsToDisplay.map((item) => <div key={`${item.workloadName}-${item.podName}`}>{item.podName}</div>) : null
+        const hasMorePods = text.podList.length > maxDisplayPods
+        const morePods = hasMorePods ? <div style={{ color: '#108ee9', fontWeight: 'bold' }}>Show all ({text.podList.length})...</div> : null
         return (
           <Tooltip placement="top" title={title}>
             <a onClick={() => { showWorkloadsStatusDetail(text) }} className={style.workloadContainer} style={{ margin: 0 }}>
               <div style={text.lastPodRefAt && ele ? { background: 'rgba(241, 196, 15, 0.1)', padding: '5px' } : {}}>
                 {ele}
+                {morePods}
               </div>
               <div>{record.controllers ? record.controllers.map(item => <div style={{ fontFamily: 'monospace', margin: '2px 0px' }} key={item.hostId}>{item.hostId ? <span>on {item.hostId}</span> : <span></span>}</div>) : ''}</div>
             </a>

--- a/src/routes/volume/WorkloadDetailModal.js
+++ b/src/routes/volume/WorkloadDetailModal.js
@@ -54,8 +54,8 @@ const modal = ({
           <span style={{ marginLeft: 10, color: '#666' }}>{filteredPodList.length} / {podList.length} pods</span>
         </div>
       ) : ''}
-      <div style={{ width: '100%', overflow: 'auto' }}>
-        <div style={{ display: 'flex', whiteSpace: 'nowrap', width: '100%' }}>
+      <div style={{ width: '100%', maxHeight: '60vh', overflow: 'auto' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
           {CardItem}
         </div>
         {keyword && !filteredPodList.length ? <div style={{ color: '#666', textAlign: 'center', padding: 24 }}>No pods match the filter</div> : ''}


### PR DESCRIPTION
### What this PR does / why we need it

I have cases where a volume has a large number of pods attached to it, sometimes up to 500. This makes the volume list difficult to use, as individual rows become extremely tall due to the number of pods displayed.

This PR displays only the first three pods directly in the volume list, while the remaining pods can still be viewed in the existing popup.

<img width="1567" height="152" alt="Screenshot from 2026-08-12 19-37-47" src="https://github.com/user-attachments/assets/379f3a3c-f4c4-45c2-9691-a377c0196f48" />

The popup has also been adjusted to display the pods vertically instead of horizontally, making large lists easier to read.

<img width="531" height="785" alt="Screenshot from 2026-08-12 19-40-57" src="https://github.com/user-attachments/assets/fd45aed2-fea2-41fd-9cdf-734e7e1684a9" />

https://github.com/longhorn/longhorn/issues/13851
