### PR TITLE
feat: add age-based retention policy for recurring job

### DIFF
--- a/src/assets/styles/antd-customize/generic.less
+++ b/src/assets/styles/antd-customize/generic.less
@@ -130,9 +130,7 @@
       box-shadow: none;
     }
   }
-  .ant-radio-inner {
-    top: -3px !important;
-  }
+
   .ant-confirm-body .ant-confirm-title {
     word-wrap: break-word;
   }

--- a/src/components/DropOption/DropOption.js
+++ b/src/components/DropOption/DropOption.js
@@ -13,7 +13,7 @@ const DropOption = ({ onMenuClick, menuOptions = [], buttonStyle, dropdownProps,
   })
   return (<Dropdown
     placement="bottomLeft"
-    trigger="click"
+    trigger={['click']}
     overlay={<Menu onClick={onMenuClick} style={{ maxHeight: 'calc(100vh - 200px)', overflowY: 'auto' }}>{menu}</Menu>}
     {...dropdownProps}
   >

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -40,7 +40,7 @@ class Filter extends React.Component {
   handleSubmit = () => {
     if (this.props.onSearch) {
       this.setState(
-        (prevState) => ({ value: prevState.value.trim() }),
+        (prevState) => ({ value: (prevState.value || '').trim() }),
         () => this.props.onSearch({ ...this.state })
       )
     }
@@ -88,6 +88,11 @@ class Filter extends React.Component {
   }
 
   handleFieldChange = (field) => {
+    // Retention policy filtering defaults to count-based.
+    if (field === 'retentionPolicy') {
+      this.setState({ ...this.state, field, value: 'count-based' })
+      return
+    }
     this.setState({ ...this.state, field })
   }
 
@@ -211,6 +216,20 @@ class Filter extends React.Component {
           {this.props.availableOption.map(item => (<Option key={item.name} value={item.value}>{item.name}</Option>))}
         </Select>
       )
+    } else if (this.state.field === 'retentionPolicy' && this.props.retentionPolicyOption) {
+      valueForm = (
+        <Select
+          key="retentionPolicy"
+          style={{ width: '100%' }}
+          size="large"
+          allowClear
+          value={this.state.value || undefined}
+          defaultValue="count-based"
+          onChange={this.handleAvailableValueChange}
+        >
+          {this.props.retentionPolicyOption.map(item => (<Option key={item.value} value={item.value}>{item.name}</Option>))}
+        </Select>
+      )
     }
 
     let content = ''
@@ -255,6 +274,7 @@ Filter.propTypes = {
   recurringJobIsGroupOption: PropTypes.array,
   createdFromOption: PropTypes.array,
   availableOption: PropTypes.array,
+  retentionPolicyOption: PropTypes.array,
 }
 
 export default Filter

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -224,7 +224,6 @@ class Filter extends React.Component {
           size="large"
           allowClear
           value={this.state.value || undefined}
-          defaultValue="count-based"
           onChange={this.handleAvailableValueChange}
         >
           {this.props.retentionPolicyOption.map(item => (<Option key={item.value} value={item.value}>{item.name}</Option>))}

--- a/src/routes/recurringJob/CreateRecurringJob.js
+++ b/src/routes/recurringJob/CreateRecurringJob.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Form, Input, Icon, Button, Select, InputNumber, Checkbox, Tooltip } from 'antd'
+import { Form, Input, Icon, Button, Select, InputNumber, Checkbox, Tooltip, Radio } from 'antd'
 import { ModalBlur, ReactCron } from '../../components'
 
 const Option = Select.Option
@@ -42,6 +42,20 @@ const formItemLayoutWithOutForAddLabels = {
 
 const noRetain = (val) => {
   return val === 'snapshot-cleanup' || val === 'filesystem-trim'
+}
+
+// Tasks that support the age-based retention policy.
+const AGE_BASED_TASKS = ['backup', 'snapshot', 'system-backup']
+
+// Parse a Go duration string (e.g. "2h30m", "8760h", "10m") into hours + minutes.
+const parseRetainAge = (str) => {
+  if (!str) {
+    return { hours: 0, minutes: 0 }
+  }
+  const h = /(\d+)h/.exec(str)
+  const m = /(\d+)m/.exec(str)
+  const total = (h ? parseInt(h[1], 10) * 60 : 0) + (m ? parseInt(m[1], 10) : 0)
+  return { hours: Math.floor(total / 60), minutes: total % 60 }
 }
 
 const modal = ({
@@ -104,6 +118,14 @@ const modal = ({
       if (data.keysForlabels) {
         delete data.keysForlabels
       }
+      // Build the age-based retainAge duration (e.g. "2h30m") and drop the helper inputs.
+      if (data.retentionPolicy === 'age-based') {
+        const hours = Number(data.retainAgeHours) || 0
+        const minutes = Number(data.retainAgeMinutes) || 0
+        data.retainAge = `${hours}h${minutes}m`
+      }
+      delete data.retainAgeHours
+      delete data.retainAgeMinutes
       delete data.defaultGroup
       if (data.parametersKey && data.parametersValue?.toString()) {
         data.parameters = {}
@@ -171,6 +193,13 @@ const modal = ({
       cron: cronProps.cron,
     })
     cronProps.onCronCancel()
+  }
+
+  const onChangeRetentionPolicy = (e) => {
+    // Age-based only supports backup / snapshot / system-backup tasks.
+    if (e.target.value === 'age-based' && !AGE_BASED_TASKS.includes(getFieldValue('task'))) {
+      setFieldsValue({ task: 'snapshot' })
+    }
   }
 
   const onChangeTask = (val) => {
@@ -303,6 +332,9 @@ const modal = ({
   const showGroup = !isSystemBackup
   const showLabels = !isSystemBackup
   const systemBackupParameterOptions = ['if-not-present', 'always', 'disabled']
+  const retentionPolicy = getFieldValue('retentionPolicy') || (isEdit ? item.retentionPolicy : '') || 'count-based'
+  const isAgeBased = retentionPolicy === 'age-based'
+  const initialRetainAge = parseRetainAge(isEdit ? item.retainAge : '')
 
   return (
     <ModalBlur {...modalOpts}>
@@ -318,6 +350,22 @@ const modal = ({
             ],
           })(<Input disabled={isEdit || addForVolume} style={{ width: '80%' }} />)}
         </FormItem>
+        <FormItem label="Retention Policy" required {...formItemLayout}>
+          {getFieldDecorator('retentionPolicy', {
+            initialValue: isEdit ? (item.retentionPolicy || 'count-based') : 'count-based',
+            rules: [
+              {
+                required: true,
+                message: 'Please select a retention policy',
+              },
+            ],
+          })(
+            <Radio.Group disabled={isEdit} onChange={onChangeRetentionPolicy} style={{ marginTop: 8, marginLeft: 8, display: 'inline-flex', alignItems: 'center' }}>
+              <Radio value="count-based" style={{ display: 'inline-flex', alignItems: 'center' }}>Count-based</Radio>
+              <Radio value="age-based" style={{ display: 'inline-flex', alignItems: 'center' }}>Age-based</Radio>
+            </Radio.Group>
+          )}
+        </FormItem>
         <div style={{ display: 'flex' }}>
           <FormItem label="Task" style={{ flex: 1 }} hasFeedback labelCol={{ span: showForceCreateCheckbox() ? 7 : 4 }} wrapperCol={{ span: 17 }}>
             {getFieldDecorator('task', {
@@ -328,12 +376,18 @@ const modal = ({
                 },
               ],
             })(<Select disabled={isEdit} style={{ width: '80%' }} onChange={onChangeTask}>
-                <Option value="backup">Backup</Option>
-                <Option value="snapshot">Snapshot</Option>
-                <Option value="snapshot-delete">Snapshot Delete</Option>
-                <Option value="snapshot-cleanup">Snapshot Cleanup</Option>
-                <Option value="system-backup">System Backup</Option>
-                <Option value="filesystem-trim">Filesystem Trim</Option>
+                {isAgeBased ? [
+                  <Option key="backup" value="backup">Backup</Option>,
+                  <Option key="snapshot" value="snapshot">Snapshot</Option>,
+                  <Option key="system-backup" value="system-backup">System Backup</Option>,
+                ] : [
+                  <Option key="backup" value="backup">Backup</Option>,
+                  <Option key="snapshot" value="snapshot">Snapshot</Option>,
+                  <Option key="snapshot-delete" value="snapshot-delete">Snapshot Delete</Option>,
+                  <Option key="snapshot-cleanup" value="snapshot-cleanup">Snapshot Cleanup</Option>,
+                  <Option key="system-backup" value="system-backup">System Backup</Option>,
+                  <Option key="filesystem-trim" value="filesystem-trim">Filesystem Trim</Option>,
+                ]}
             </Select>)}
           </FormItem>
           {showForceCreateCheckbox() && <Tooltip
@@ -347,16 +401,32 @@ const modal = ({
               </FormItem>
           </Tooltip>}
         </div>
-        <FormItem label="Retain" hasFeedback {...formItemLayout}>
+        <FormItem label="Retain" hasFeedback {...formItemLayout} style={{ display: isAgeBased ? 'none' : undefined }}>
           {getFieldDecorator('retain', {
             initialValue: isEdit ? item.retain : 1,
             rules: [
               {
-                required: true,
+                required: !isAgeBased,
               },
             ],
           })(<InputNumber disabled={noRetain(getFieldValue('task'))} style={{ width: '80%' }} min={0} />)}
         </FormItem>
+        {isAgeBased && (
+          <FormItem label="Retain Age" hasFeedback {...formItemLayout}>
+            <div style={{ display: 'flex', alignItems: 'center' }}>
+              {getFieldDecorator('retainAgeHours', {
+                initialValue: initialRetainAge.hours,
+                rules: [{ required: true }],
+              })(<InputNumber min={0} style={{ width: 120 }} />)}
+              <span style={{ margin: '0 8px' }}>hours</span>
+              {getFieldDecorator('retainAgeMinutes', {
+                initialValue: initialRetainAge.minutes,
+                rules: [{ required: true }],
+              })(<InputNumber min={0} style={{ width: 120 }} />)}
+              <span style={{ marginLeft: 8 }}>minutes</span>
+            </div>
+          </FormItem>
+        )}
         {showConcurrency && (
           <FormItem label="Concurrency" hasFeedback {...formItemLayout}>
             {getFieldDecorator('concurrency', {

--- a/src/routes/recurringJob/CreateRecurringJob.js
+++ b/src/routes/recurringJob/CreateRecurringJob.js
@@ -13,7 +13,7 @@ const formItemLayout = {
     span: 4,
   },
   wrapperCol: {
-    span: 17,
+    span: 20,
   },
 }
 
@@ -71,6 +71,7 @@ const modal = ({
     validateFields,
     getFieldsValue,
     getFieldValue,
+    getFieldError,
     setFieldsValue,
   },
 }) => {
@@ -412,18 +413,27 @@ const modal = ({
           })(<InputNumber disabled={noRetain(getFieldValue('task'))} style={{ width: '80%' }} min={0} />)}
         </FormItem>
         {isAgeBased && (
-          <FormItem label="Retain Age" hasFeedback {...formItemLayout}>
+          <FormItem label="Retain Age" required {...formItemLayout}>
             <div style={{ display: 'flex', alignItems: 'center' }}>
-              {getFieldDecorator('retainAgeHours', {
-                initialValue: initialRetainAge.hours,
-                rules: [{ required: true }],
-              })(<InputNumber min={0} style={{ width: 120 }} />)}
-              <span style={{ margin: '0 8px' }}>hours</span>
-              {getFieldDecorator('retainAgeMinutes', {
-                initialValue: initialRetainAge.minutes,
-                rules: [{ required: true }],
-              })(<InputNumber min={0} style={{ width: 120 }} />)}
-              <span style={{ marginLeft: 8 }}>minutes</span>
+              <FormItem style={{ marginBottom: 0, marginRight: 8 }} help={''}>
+                {getFieldDecorator('retainAgeHours', {
+                  initialValue: initialRetainAge.hours,
+                  rules: [{ required: true, message: 'retainAgeHours is required' }],
+                })(<InputNumber min={0} style={{ width: 120 }} />)}
+              </FormItem>
+              <span style={{ marginRight: 8 }}>hours</span>
+              <FormItem style={{ marginBottom: 0, marginRight: 8 }} help={''}>
+                {getFieldDecorator('retainAgeMinutes', {
+                  initialValue: initialRetainAge.minutes,
+                  rules: [{ required: true, message: 'retainAgeMinutes is required' }],
+                })(<InputNumber min={0} style={{ width: 120 }} />)}
+              </FormItem>
+              <span>minutes</span>
+              {(getFieldError('retainAgeHours') || getFieldError('retainAgeMinutes')) && (
+                <span style={{ lineHeight: 1.5, marginLeft: 12, color: '#f5222d' }}>
+                  {[...(getFieldError('retainAgeHours') || []), ...(getFieldError('retainAgeMinutes') || [])].join(', ')}
+                </span>
+              )}
             </div>
           </FormItem>
         )}

--- a/src/routes/recurringJob/CreateRecurringJob.js
+++ b/src/routes/recurringJob/CreateRecurringJob.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Form, Input, Icon, Button, Select, InputNumber, Checkbox, Tooltip, Radio } from 'antd'
 import { ModalBlur, ReactCron } from '../../components'
+import { parseRetainAge } from '../../utils/recurringJob'
 
 const Option = Select.Option
 const FormItem = Form.Item
@@ -46,17 +47,6 @@ const noRetain = (val) => {
 
 // Tasks that support the age-based retention policy.
 const AGE_BASED_TASKS = ['backup', 'snapshot', 'system-backup']
-
-// Parse a Go duration string (e.g. "2h30m", "8760h", "10m") into hours + minutes.
-const parseRetainAge = (str) => {
-  if (!str) {
-    return { hours: 0, minutes: 0 }
-  }
-  const h = /(\d+)h/.exec(str)
-  const m = /(\d+)m/.exec(str)
-  const total = (h ? parseInt(h[1], 10) * 60 : 0) + (m ? parseInt(m[1], 10) : 0)
-  return { hours: Math.floor(total / 60), minutes: total % 60 }
-}
 
 const modal = ({
   item,

--- a/src/routes/recurringJob/CreateRecurringJob.js
+++ b/src/routes/recurringJob/CreateRecurringJob.js
@@ -110,11 +110,14 @@ const modal = ({
         delete data.keysForlabels
       }
       // Build the age-based retainAge duration (e.g. "2h30m") and drop the helper inputs.
+      // Days are folded into hours so the API only receives XhXm (e.g. 1d1h -> 25h).
       if (data.retentionPolicy === 'age-based') {
-        const hours = Number(data.retainAgeHours) || 0
+        const days = Number(data.retainAgeDays) || 0
+        const hours = (Number(data.retainAgeHours) || 0) + days * 24
         const minutes = Number(data.retainAgeMinutes) || 0
         data.retainAge = `${hours}h${minutes}m`
       }
+      delete data.retainAgeDays
       delete data.retainAgeHours
       delete data.retainAgeMinutes
       delete data.defaultGroup
@@ -408,6 +411,13 @@ const modal = ({
           <FormItem label="Retain Age" required {...formItemLayout}>
             <div style={{ display: 'flex', alignItems: 'center' }}>
               <FormItem style={{ marginBottom: 0, marginRight: 8 }} help={''}>
+                {getFieldDecorator('retainAgeDays', {
+                  initialValue: initialRetainAge.days,
+                  rules: [{ required: true, message: 'retainAgeDays is required' }],
+                })(<InputNumber min={0} style={{ width: 120 }} />)}
+              </FormItem>
+              <span style={{ marginRight: 8 }}>days</span>
+              <FormItem style={{ marginBottom: 0, marginRight: 8 }} help={''}>
                 {getFieldDecorator('retainAgeHours', {
                   initialValue: initialRetainAge.hours,
                   rules: [{ required: true, message: 'retainAgeHours is required' }],
@@ -421,12 +431,12 @@ const modal = ({
                 })(<InputNumber min={0} style={{ width: 120 }} />)}
               </FormItem>
               <span>minutes</span>
-              {(getFieldError('retainAgeHours') || getFieldError('retainAgeMinutes')) && (
-                <span style={{ lineHeight: 1.5, marginLeft: 12, color: '#f5222d' }}>
-                  {[...(getFieldError('retainAgeHours') || []), ...(getFieldError('retainAgeMinutes') || [])].join(', ')}
-                </span>
-              )}
             </div>
+            {(getFieldError('retainAgeDays') || getFieldError('retainAgeHours') || getFieldError('retainAgeMinutes')) && (
+              <div style={{ lineHeight: 1.5, marginTop: 4, color: '#f5222d' }}>
+                {[...(getFieldError('retainAgeDays') || []), ...(getFieldError('retainAgeHours') || []), ...(getFieldError('retainAgeMinutes') || [])].join(', ')}
+              </div>
+            )}
           </FormItem>
         )}
         {showConcurrency && (

--- a/src/routes/recurringJob/CreateRecurringJob.js
+++ b/src/routes/recurringJob/CreateRecurringJob.js
@@ -335,6 +335,8 @@ const modal = ({
   const systemBackupParameterOptions = ['if-not-present', 'always', 'disabled']
   const retentionPolicy = getFieldValue('retentionPolicy') || (isEdit ? item.retentionPolicy : '') || 'count-based'
   const isAgeBased = retentionPolicy === 'age-based'
+  // Retention policy is only editable when the task is backup / snapshot / system-backup.
+  const canEditRetentionPolicy = AGE_BASED_TASKS.includes((getFieldValue('task') || '').replace('-force-create', ''))
   const initialRetainAge = parseRetainAge(isEdit ? item.retainAge : '')
 
   return (
@@ -361,7 +363,7 @@ const modal = ({
               },
             ],
           })(
-            <Radio.Group disabled={isEdit} onChange={onChangeRetentionPolicy} style={{ marginTop: 8, marginLeft: 8, display: 'inline-flex', alignItems: 'center' }}>
+            <Radio.Group disabled={isEdit && !canEditRetentionPolicy} onChange={onChangeRetentionPolicy} style={{ marginTop: 8, marginLeft: 8, display: 'inline-flex', alignItems: 'center' }}>
               <Radio value="count-based" style={{ display: 'inline-flex', alignItems: 'center' }}>Count-based</Radio>
               <Radio value="age-based" style={{ display: 'inline-flex', alignItems: 'center' }}>Age-based</Radio>
             </Radio.Group>

--- a/src/routes/recurringJob/RecurringJobList.js
+++ b/src/routes/recurringJob/RecurringJobList.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Table } from 'antd'
+import { Table, Tag } from 'antd'
 import RecurringJobActions from './RecurringJobActions'
 import prettyCron from '../../utils/prettycron'
 import { pagination } from '../../utils/page'
@@ -99,8 +99,8 @@ function list({ loading, dataSource, rowSelection, height, deleteRecurringJob, e
       render: (text, record) => {
         return (
           <div>{record.labels && Object.keys(record.labels).map((key) => {
-            return key ? `${key}: ${record.labels[key]}` : ''
-          }).join(', ')}</div>
+            return key ? <Tag key={key}>{`${key}: ${record.labels[key]}`}</Tag> : ''
+          })}</div>
         )
       },
     }, {

--- a/src/routes/recurringJob/RecurringJobList.js
+++ b/src/routes/recurringJob/RecurringJobList.js
@@ -45,12 +45,30 @@ function list({ loading, dataSource, rowSelection, height, deleteRecurringJob, e
         )
       },
     }, {
+      title: 'Retention Policy',
+      key: 'retentionPolicy',
+      width: 140,
+      render: (record) => {
+        return (
+          <div>{record.retentionPolicy || 'count-based'}</div>
+        )
+      },
+    }, {
       title: 'Retain',
       key: 'retain',
       width: 120,
       render: (record) => {
         return (
-          <div>{record.retain}</div>
+          <div>{record.retentionPolicy === 'age-based' ? '-' : record.retain}</div>
+        )
+      },
+    }, {
+      title: 'Retain Age',
+      key: 'retainAge',
+      width: 120,
+      render: (record) => {
+        return (
+          <div>{record.retentionPolicy === 'age-based' ? record.retainAge : '-'}</div>
         )
       },
     }, {
@@ -65,7 +83,7 @@ function list({ loading, dataSource, rowSelection, height, deleteRecurringJob, e
     }, {
       title: 'Parameters',
       key: 'parameters',
-      width: 200,
+      width: 160,
       render: (record) => {
         return (
           <div>{record.parameters && Object.keys(record.parameters).map((key) => {
@@ -77,7 +95,7 @@ function list({ loading, dataSource, rowSelection, height, deleteRecurringJob, e
       title: 'Labels',
       dataIndex: 'labels',
       key: 'labels',
-      width: 200,
+      width: 160,
       render: (text, record) => {
         return (
           <div>{record.labels && Object.keys(record.labels).map((key) => {
@@ -89,7 +107,7 @@ function list({ loading, dataSource, rowSelection, height, deleteRecurringJob, e
       title: 'Groups',
       dataIndex: 'groups',
       key: 'groups',
-      width: 200,
+      width: 120,
       render: (text, record) => {
         return (
           <div>{record.groups && record.groups.join(', ')}</div>

--- a/src/routes/recurringJob/RecurringJobList.js
+++ b/src/routes/recurringJob/RecurringJobList.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { Table, Tag } from 'antd'
 import RecurringJobActions from './RecurringJobActions'
 import prettyCron from '../../utils/prettycron'
+import { formatRetainAge } from '../../utils/recurringJob'
 import { pagination } from '../../utils/page'
 
 function list({ loading, dataSource, rowSelection, height, deleteRecurringJob, editRecurringJob }) {
@@ -68,7 +69,7 @@ function list({ loading, dataSource, rowSelection, height, deleteRecurringJob, e
       width: 120,
       render: (record) => {
         return (
-          <div>{record.retentionPolicy === 'age-based' ? record.retainAge : '-'}</div>
+          <div>{record.retentionPolicy === 'age-based' ? formatRetainAge(record.retainAge) : '-'}</div>
         )
       },
     }, {

--- a/src/routes/recurringJob/index.js
+++ b/src/routes/recurringJob/index.js
@@ -115,6 +115,8 @@ class RecurringJob extends React.Component {
           return item.task === value
         }
         return false
+      } else if (field === 'retentionPolicy' && value !== '') {
+        return (item.retentionPolicy || 'count-based') === value
       }
       return true
     })
@@ -212,6 +214,11 @@ class RecurringJob extends React.Component {
         { value: 'groups', name: 'Group' },
         { value: 'label', name: 'Label' },
         { value: 'type', name: 'Type' },
+        { value: 'retentionPolicy', name: 'Retention Policy' },
+      ],
+      retentionPolicyOption: [
+        { value: 'count-based', name: 'Count-based' },
+        { value: 'age-based', name: 'Age-based' },
       ],
       onSearch(filter) {
         const { field: filterField, value: filterValue } = filter

--- a/src/routes/volume/detail/CreateRecurringJob.js
+++ b/src/routes/volume/detail/CreateRecurringJob.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Form, Input, Icon, Button, Select, Checkbox, InputNumber, Tabs, Tooltip, Radio } from 'antd'
 import { ModalBlur, ReactCron } from '../../../components'
+import { parseRetainAge } from '../../../utils/recurringJob'
 
 const Option = Select.Option
 const FormItem = Form.Item
@@ -48,17 +49,6 @@ const noRetain = (val) => {
 
 // Tasks that support the age-based retention policy (system-backup isn't offered here).
 const AGE_BASED_TASKS = ['backup', 'snapshot']
-
-// Parse a Go duration string (e.g. "2h30m", "8760h", "10m") into hours + minutes.
-const parseRetainAge = (str) => {
-  if (!str) {
-    return { hours: 0, minutes: 0 }
-  }
-  const h = /(\d+)h/.exec(str)
-  const m = /(\d+)m/.exec(str)
-  const total = (h ? parseInt(h[1], 10) * 60 : 0) + (m ? parseInt(m[1], 10) : 0)
-  return { hours: Math.floor(total / 60), minutes: total % 60 }
-}
 
 const modal = ({
   item,

--- a/src/routes/volume/detail/CreateRecurringJob.js
+++ b/src/routes/volume/detail/CreateRecurringJob.js
@@ -332,6 +332,8 @@ const modal = ({
   const showParametersField = getFieldValue('task') === 'backup' || getFieldValue('task') === 'backup-force-create'
   const retentionPolicy = getFieldValue('retentionPolicy') || (isEdit ? item.retentionPolicy : '') || 'count-based'
   const isAgeBased = retentionPolicy === 'age-based'
+  // Retention policy is only editable when the task is backup / snapshot.
+  const canEditRetentionPolicy = AGE_BASED_TASKS.includes((getFieldValue('task') || '').replace('-force-create', ''))
   const initialRetainAge = parseRetainAge(isEdit ? item.retainAge : '')
   return (
     <ModalBlur {...modalOpts}>
@@ -359,7 +361,7 @@ const modal = ({
                     },
                   ],
                 })(
-                  <Radio.Group disabled={isEdit} onChange={onChangeRetentionPolicy} style={{ marginLeft: 8, display: 'inline-flex', alignItems: 'center' }}>
+                  <Radio.Group disabled={isEdit && !canEditRetentionPolicy} onChange={onChangeRetentionPolicy} style={{ marginLeft: 8, display: 'inline-flex', alignItems: 'center' }}>
                     <Radio value="count-based" style={{ display: 'inline-flex', alignItems: 'center' }}>Count-based</Radio>
                     <Radio value="age-based" style={{ display: 'inline-flex', alignItems: 'center' }}>Age-based</Radio>
                   </Radio.Group>

--- a/src/routes/volume/detail/CreateRecurringJob.js
+++ b/src/routes/volume/detail/CreateRecurringJob.js
@@ -111,11 +111,14 @@ const modal = ({
         delete data.keysForlabels
       }
       // Build the age-based retainAge duration (e.g. "2h30m") and drop the helper inputs.
+      // Days are folded into hours so the API only receives XhXm (e.g. 1d1h -> 25h).
       if (data.retentionPolicy === 'age-based') {
-        const hours = Number(data.retainAgeHours) || 0
+        const days = Number(data.retainAgeDays) || 0
+        const hours = (Number(data.retainAgeHours) || 0) + days * 24
         const minutes = Number(data.retainAgeMinutes) || 0
         data.retainAge = `${hours}h${minutes}m`
       }
+      delete data.retainAgeDays
       delete data.retainAgeHours
       delete data.retainAgeMinutes
       delete data.defaultGroup
@@ -404,6 +407,13 @@ const modal = ({
                 <FormItem label="Retain Age" required {...formItemLayout}>
                   <div style={{ display: 'flex', alignItems: 'center' }}>
                     <FormItem style={{ marginBottom: 0, marginRight: 8 }} help={''}>
+                      {getFieldDecorator('retainAgeDays', {
+                        initialValue: initialRetainAge.days,
+                        rules: [{ required: true, message: 'retainAgeDays is required' }],
+                      })(<InputNumber min={0} style={{ width: 120 }} />)}
+                    </FormItem>
+                    <span style={{ marginRight: 8 }}>days</span>
+                    <FormItem style={{ marginBottom: 0, marginRight: 8 }} help={''}>
                       {getFieldDecorator('retainAgeHours', {
                         initialValue: initialRetainAge.hours,
                         rules: [{ required: true, message: 'retainAgeHours is required' }],
@@ -417,12 +427,12 @@ const modal = ({
                       })(<InputNumber min={0} style={{ width: 120 }} />)}
                     </FormItem>
                     <span>minutes</span>
-                    {(getFieldError('retainAgeHours') || getFieldError('retainAgeMinutes')) && (
-                      <span style={{ lineHeight: 1.5, marginLeft: 12, color: '#f5222d' }}>
-                        {[...(getFieldError('retainAgeHours') || []), ...(getFieldError('retainAgeMinutes') || [])].join(', ')}
-                      </span>
-                    )}
                   </div>
+                  {(getFieldError('retainAgeDays') || getFieldError('retainAgeHours') || getFieldError('retainAgeMinutes')) && (
+                    <div style={{ lineHeight: 1.5, marginTop: 4, color: '#f5222d' }}>
+                      {[...(getFieldError('retainAgeDays') || []), ...(getFieldError('retainAgeHours') || []), ...(getFieldError('retainAgeMinutes') || [])].join(', ')}
+                    </div>
+                  )}
                 </FormItem>
               )}
               <FormItem label="Concurrency" hasFeedback {...formItemLayout}>

--- a/src/routes/volume/detail/CreateRecurringJob.js
+++ b/src/routes/volume/detail/CreateRecurringJob.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Form, Input, Icon, Button, Select, Checkbox, InputNumber, Tabs, Tooltip } from 'antd'
+import { Form, Input, Icon, Button, Select, Checkbox, InputNumber, Tabs, Tooltip, Radio } from 'antd'
 import { ModalBlur, ReactCron } from '../../../components'
 
 const Option = Select.Option
@@ -15,7 +15,7 @@ const formItemLayout = {
     span: 4,
   },
   wrapperCol: {
-    span: 17,
+    span: 20,
   },
 }
 
@@ -46,6 +46,20 @@ const noRetain = (val) => {
   return val === 'snapshot-cleanup' || val === 'filesystem-trim'
 }
 
+// Tasks that support the age-based retention policy (system-backup isn't offered here).
+const AGE_BASED_TASKS = ['backup', 'snapshot']
+
+// Parse a Go duration string (e.g. "2h30m", "8760h", "10m") into hours + minutes.
+const parseRetainAge = (str) => {
+  if (!str) {
+    return { hours: 0, minutes: 0 }
+  }
+  const h = /(\d+)h/.exec(str)
+  const m = /(\d+)m/.exec(str)
+  const total = (h ? parseInt(h[1], 10) * 60 : 0) + (m ? parseInt(m[1], 10) : 0)
+  return { hours: Math.floor(total / 60), minutes: total % 60 }
+}
+
 const modal = ({
   item,
   recurringJobOptions,
@@ -60,6 +74,7 @@ const modal = ({
     validateFields,
     getFieldsValue,
     getFieldValue,
+    getFieldError,
     setFieldsValue,
   },
 }) => {
@@ -105,6 +120,14 @@ const modal = ({
       if (data.keysForlabels) {
         delete data.keysForlabels
       }
+      // Build the age-based retainAge duration (e.g. "2h30m") and drop the helper inputs.
+      if (data.retentionPolicy === 'age-based') {
+        const hours = Number(data.retainAgeHours) || 0
+        const minutes = Number(data.retainAgeMinutes) || 0
+        data.retainAge = `${hours}h${minutes}m`
+      }
+      delete data.retainAgeHours
+      delete data.retainAgeMinutes
       delete data.defaultGroup
       if (data.parametersKey && data.parametersValue?.toString()) {
         data.parameters = {}
@@ -166,6 +189,12 @@ const modal = ({
       cron: cronProps.cron,
     })
     cronProps.onCronCancel()
+  }
+  const onChangeRetentionPolicy = (e) => {
+    // Age-based only supports backup / snapshot tasks here.
+    if (e.target.value === 'age-based' && !AGE_BASED_TASKS.includes(getFieldValue('task'))) {
+      setFieldsValue({ task: 'snapshot' })
+    }
   }
   const onChangeTask = (val) => {
     if (noRetain(val)) {
@@ -301,6 +330,9 @@ const modal = ({
 
   const isParametersValueRequired = !!getFieldValue('parametersKey')
   const showParametersField = getFieldValue('task') === 'backup' || getFieldValue('task') === 'backup-force-create'
+  const retentionPolicy = getFieldValue('retentionPolicy') || (isEdit ? item.retentionPolicy : '') || 'count-based'
+  const isAgeBased = retentionPolicy === 'age-based'
+  const initialRetainAge = parseRetainAge(isEdit ? item.retainAge : '')
   return (
     <ModalBlur {...modalOpts}>
       <Tabs tabPosition={'top'} type="card" onChange={changeTab} defaultActiveKey="1">
@@ -317,6 +349,22 @@ const modal = ({
                   ],
                 })(<Input disabled={isEdit || addForVolume} style={{ width: '80%' }} />)}
               </FormItem>
+              <FormItem label="Retention Policy" required {...formItemLayout}>
+                {getFieldDecorator('retentionPolicy', {
+                  initialValue: isEdit ? (item.retentionPolicy || 'count-based') : 'count-based',
+                  rules: [
+                    {
+                      required: true,
+                      message: 'Please select a retention policy',
+                    },
+                  ],
+                })(
+                  <Radio.Group disabled={isEdit} onChange={onChangeRetentionPolicy} style={{ marginLeft: 8, display: 'inline-flex', alignItems: 'center' }}>
+                    <Radio value="count-based" style={{ display: 'inline-flex', alignItems: 'center' }}>Count-based</Radio>
+                    <Radio value="age-based" style={{ display: 'inline-flex', alignItems: 'center' }}>Age-based</Radio>
+                  </Radio.Group>
+                )}
+              </FormItem>
               <div style={{ display: 'flex' }}>
                 <FormItem label="Task" hasFeedback style={{ flex: 1 }} labelCol={{ span: showForceCreateCheckbox() ? 7 : 4 }} wrapperCol={{ span: 17 }}>
                   {getFieldDecorator('task', {
@@ -327,11 +375,16 @@ const modal = ({
                       },
                     ],
                   })(<Select disabled={isEdit} style={{ width: '80%' }} onChange={onChangeTask}>
-                      <Option value="backup">Backup</Option>
-                      <Option value="snapshot">Snapshot</Option>
-                      <Option value="snapshot-delete">Snapshot Delete</Option>
-                      <Option value="snapshot-cleanup">Snapshot Cleanup</Option>
-                      <Option value="filesystem-trim">Filesystem Trim</Option>
+                      {isAgeBased ? [
+                        <Option key="backup" value="backup">Backup</Option>,
+                        <Option key="snapshot" value="snapshot">Snapshot</Option>,
+                      ] : [
+                        <Option key="backup" value="backup">Backup</Option>,
+                        <Option key="snapshot" value="snapshot">Snapshot</Option>,
+                        <Option key="snapshot-delete" value="snapshot-delete">Snapshot Delete</Option>,
+                        <Option key="snapshot-cleanup" value="snapshot-cleanup">Snapshot Cleanup</Option>,
+                        <Option key="filesystem-trim" value="filesystem-trim">Filesystem Trim</Option>,
+                      ]}
                   </Select>)}
                 </FormItem>
                 {showForceCreateCheckbox() && <Tooltip
@@ -345,16 +398,41 @@ const modal = ({
                     </FormItem>
                 </Tooltip>}
               </div>
-              <FormItem label="Retain" hasFeedback {...formItemLayout}>
+              <FormItem label="Retain" hasFeedback {...formItemLayout} style={{ display: isAgeBased ? 'none' : undefined }}>
                 {getFieldDecorator('retain', {
                   initialValue: isEdit ? item.retain : 1,
                   rules: [
                     {
-                      required: true,
+                      required: !isAgeBased,
                     },
                   ],
                 })(<InputNumber disabled={noRetain(getFieldValue('task'))} style={{ width: '80%' }} min={0} />)}
               </FormItem>
+              {isAgeBased && (
+                <FormItem label="Retain Age" required {...formItemLayout}>
+                  <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <FormItem style={{ marginBottom: 0, marginRight: 8 }} help={''}>
+                      {getFieldDecorator('retainAgeHours', {
+                        initialValue: initialRetainAge.hours,
+                        rules: [{ required: true, message: 'retainAgeHours is required' }],
+                      })(<InputNumber min={0} style={{ width: 120 }} />)}
+                    </FormItem>
+                    <span style={{ marginRight: 8 }}>hours</span>
+                    <FormItem style={{ marginBottom: 0, marginRight: 8 }} help={''}>
+                      {getFieldDecorator('retainAgeMinutes', {
+                        initialValue: initialRetainAge.minutes,
+                        rules: [{ required: true, message: 'retainAgeMinutes is required' }],
+                      })(<InputNumber min={0} style={{ width: 120 }} />)}
+                    </FormItem>
+                    <span>minutes</span>
+                    {(getFieldError('retainAgeHours') || getFieldError('retainAgeMinutes')) && (
+                      <span style={{ lineHeight: 1.5, marginLeft: 12, color: '#f5222d' }}>
+                        {[...(getFieldError('retainAgeHours') || []), ...(getFieldError('retainAgeMinutes') || [])].join(', ')}
+                      </span>
+                    )}
+                  </div>
+                </FormItem>
+              )}
               <FormItem label="Concurrency" hasFeedback {...formItemLayout}>
                 {getFieldDecorator('concurrency', {
                   initialValue: isEdit ? item.concurrency : 1,

--- a/src/routes/volume/detail/RecurringJob.js
+++ b/src/routes/volume/detail/RecurringJob.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Card, Tabs, Button, Table, message, Icon, Tooltip, Modal, Tag } from 'antd'
 import prettyCron from '../../../utils/prettycron'
+import { formatRetainAge } from '../../../utils/recurringJob'
 import { ModalBlur } from '../../../components'
 import CreateRecurringJob from './CreateRecurringJob'
 import EditRecurringJob from '../../recurringJob/CreateRecurringJob'
@@ -474,7 +475,7 @@ class RecurringJob extends React.Component {
         width: 120,
         render: (record) => {
           return (
-            <div>{record.retentionPolicy === 'age-based' ? record.retainAge : '-'}</div>
+            <div>{record.retentionPolicy === 'age-based' ? formatRetainAge(record.retainAge) : '-'}</div>
           )
         },
       }, {

--- a/src/routes/volume/detail/RecurringJob.js
+++ b/src/routes/volume/detail/RecurringJob.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Card, Tabs, Button, Table, message, Icon, Tooltip, Modal } from 'antd'
+import { Card, Tabs, Button, Table, message, Icon, Tooltip, Modal, Tag } from 'antd'
 import prettyCron from '../../../utils/prettycron'
 import { ModalBlur } from '../../../components'
 import CreateRecurringJob from './CreateRecurringJob'
@@ -409,7 +409,7 @@ class RecurringJob extends React.Component {
         title: 'Name',
         dataIndex: 'name',
         key: 'name',
-        width: 200,
+        width: 180,
         render: (text, record) => {
           return (
             <div>
@@ -432,7 +432,7 @@ class RecurringJob extends React.Component {
         title: 'Groups',
         dataIndex: 'groups',
         key: 'groups',
-        width: 200,
+        width: 100,
         render: (text, record) => {
           return (
             <div>{record.groups && record.groups.join(', ')}</div>
@@ -451,15 +451,12 @@ class RecurringJob extends React.Component {
           )
         },
       }, {
-        title: 'Labels',
-        dataIndex: 'labels',
-        key: 'labels',
-        width: 200,
-        render: (text, record) => {
+        title: 'Retention Policy',
+        key: 'retentionPolicy',
+        width: 140,
+        render: (record) => {
           return (
-            <div>{record.labels && Object.keys(record.labels).map((key) => {
-              return key ? `${key}: ${record.labels[key]}` : ''
-            }).join(', ')}</div>
+            <div>{record.retentionPolicy || 'count-based'}</div>
           )
         },
       }, {
@@ -468,7 +465,16 @@ class RecurringJob extends React.Component {
         width: 120,
         render: (record) => {
           return (
-            <div>{record.retain}</div>
+            <div>{record.retentionPolicy === 'age-based' ? '-' : record.retain}</div>
+          )
+        },
+      }, {
+        title: 'Retain Age',
+        key: 'retainAge',
+        width: 120,
+        render: (record) => {
+          return (
+            <div>{record.retentionPolicy === 'age-based' ? record.retainAge : '-'}</div>
           )
         },
       }, {
@@ -482,10 +488,22 @@ class RecurringJob extends React.Component {
         },
       },
       {
+        title: 'Labels',
+        dataIndex: 'labels',
+        key: 'labels',
+        width: 150,
+        render: (text, record) => {
+          return (
+            <div>{record.labels && Object.keys(record.labels).map((key) => {
+              return key ? <Tag key={key}>{`${key}: ${record.labels[key]}`}</Tag> : ''
+            })}</div>
+          )
+        },
+      }, {
         title: 'Operation',
         key: 'operation',
         fixed: 'right',
-        width: 110,
+        width: 120,
         render: (text, record) => {
           return (
             <RecurringJobActions {...recurringVolumeJobActionsProps} selected={record} />

--- a/src/utils/recurringJob.js
+++ b/src/utils/recurringJob.js
@@ -1,0 +1,10 @@
+// Parse a Go duration string (e.g. "2h30m", "8760h", "10m") into hours + minutes.
+export const parseRetainAge = (str) => {
+  if (!str) {
+    return { hours: 0, minutes: 0 }
+  }
+  const h = /(\d+)h/.exec(str)
+  const m = /(\d+)m/.exec(str)
+  const total = (h ? parseInt(h[1], 10) * 60 : 0) + (m ? parseInt(m[1], 10) : 0)
+  return { hours: Math.floor(total / 60), minutes: total % 60 }
+}

--- a/src/utils/recurringJob.js
+++ b/src/utils/recurringJob.js
@@ -1,10 +1,26 @@
-// Parse a Go duration string (e.g. "2h30m", "8760h", "10m") into hours + minutes.
+// Parse a Go duration string (e.g. "2h30m", "8760h", "10m") into days + hours + minutes.
 export const parseRetainAge = (str) => {
   if (!str) {
-    return { hours: 0, minutes: 0 }
+    return { days: 0, hours: 0, minutes: 0 }
   }
   const h = /(\d+)h/.exec(str)
   const m = /(\d+)m/.exec(str)
   const total = (h ? parseInt(h[1], 10) * 60 : 0) + (m ? parseInt(m[1], 10) : 0)
-  return { hours: Math.floor(total / 60), minutes: total % 60 }
+  return { days: Math.floor(total / (60 * 24)), hours: Math.floor((total % (60 * 24)) / 60), minutes: total % 60 }
+}
+
+// Format a Go duration string into "XdXhXm" for display, dropping seconds.
+export const formatRetainAge = (str) => {
+  const { days, hours, minutes } = parseRetainAge(str)
+  const parts = []
+  if (days) {
+    parts.push(`${days}d`)
+  }
+  if (hours) {
+    parts.push(`${hours}h`)
+  }
+  if (minutes) {
+    parts.push(`${minutes}m`)
+  }
+  return parts.length ? parts.join('') : '0m'
 }


### PR DESCRIPTION
### What this PR does / why we need it

Add support for the age-based retention policy on recurring jobs, in addition to the existing count-based policy:

- Add a `Retention Policy` selector (Count-based / Age-based) to the recurring job form on both the global Recurring Job page and the Volume detail page.
- Age-based policy exposes a `Retain Age` input (hours / minutes) and is only offered for the `backup`, `snapshot` and `system-backup` tasks.
- Allow the retention policy to be changed while editing an existing recurring job (previously it was disabled in edit mode). Editing is limited to the `backup` / `snapshot` / `system-backup` tasks; other tasks remain disabled.
- Show the retention policy, retain count and retain age in the recurring job lists, and add a filter by retention policy.
- Show recurring job labels using tags.

### Issue

longhorn/longhorn#13669

### Test Result

- Create a recurring job with the age-based retention policy and verify the retain age is persisted correctly.
- Create a recurring job with the count-based retention policy and verify existing behavior is unchanged.
- Edit an existing `backup` / `snapshot` / `system-backup` recurring job and verify the retention policy can be switched between count-based and age-based.
- Verify the same behavior on both the global Recurring Job page and the Volume detail page.

### Additional documentation or context

<img width="1371" height="805" alt="image" src="https://github.com/user-attachments/assets/9f1d04b8-2d68-4595-9727-4293df818d24" />

<img width="1466" height="677" alt="Screenshot 2026-08-24 at 11 37 51 PM" src="https://github.com/user-attachments/assets/36915e9f-a542-4cbb-a46d-1e9f3e955b65" />

<img width="1469" height="808" alt="Screenshot 2026-08-24 at 11 21 59 PM" src="https://github.com/user-attachments/assets/b4df0edf-a3a7-4e39-a374-e10be43ea192" />

