### PR TITLE
ci: remove fossa scan for PR review stage

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -6,10 +6,6 @@ on:
       - v*
     tags:
       - v*
-  pull_request:
-    branches:
-      - master
-      - v*
   workflow_dispatch: {}
 
 permissions: {}


### PR DESCRIPTION
### What this PR does / why we need it
fossa scan CI job continue failed for PR review stage as API key can't be retrieved from personal repo branch.

https://github.com/longhorn/longhorn-ui/actions/runs/32506744026/job/97713908890?pr=1075

We only want to run fossa scan after the PR merged into master branch or tag.

### Issue

### Test Result

### Additional documentation or context
