### PR TITLE
fix: parse non-UTC zone abbreviations in utcStrToDate

### DIFF
--- a/src/utils/__tests__/formatter.js
+++ b/src/utils/__tests__/formatter.js
@@ -1,0 +1,32 @@
+import { utcStrToDate } from '../formatter'
+
+describe('utcStrToDate', () => {
+  const expected = new Date(Date.UTC(2024, 11, 6, 19, 7, 17))
+
+  it('should parse a UTC timestamp', () => {
+    expect(utcStrToDate('2024-12-06 19:07:17 +0000 UTC')).toEqual(expected)
+  })
+
+  it('should parse a zero-offset timestamp with a non-UTC zone abbreviation', () => {
+    expect(utcStrToDate('2024-12-06 19:07:17 +0000 WET')).toEqual(expected)
+  })
+
+  it('should apply a positive offset', () => {
+    expect(utcStrToDate('2024-12-06 20:07:17 +0100 CET')).toEqual(expected)
+    expect(utcStrToDate('2024-12-07 00:37:17 +0530 IST')).toEqual(expected)
+  })
+
+  it('should apply a negative offset', () => {
+    expect(utcStrToDate('2024-12-06 14:07:17 -0500 EST')).toEqual(expected)
+  })
+
+  it('should parse a zone without an alphabetic abbreviation', () => {
+    expect(utcStrToDate('2024-12-06 22:07:17 +0300 +03')).toEqual(expected)
+  })
+
+  it('should not parse other formats', () => {
+    expect(utcStrToDate('2024-12-06T19:07:17Z')).toBe('Invalid UTC Date')
+    expect(utcStrToDate('2024-12-06 19:07:17')).toBe('Invalid UTC Date')
+    expect(utcStrToDate('not a date')).toBe('Invalid UTC Date')
+  })
+})

--- a/src/utils/__tests__/sort.js
+++ b/src/utils/__tests__/sort.js
@@ -1,8 +1,17 @@
-import { getPropValue } from '../sort'
+import { getPropValue, sortVolume } from '../sort'
 
 describe('sort', () => {
   it('getPropValue should be ok', () => {
     const val = getPropValue({ a: 1 }, 'a')
     expect(val).toBe(1)
+  })
+
+  it('sortVolume should order by created time regardless of zone abbreviation', () => {
+    const volumes = [
+      { name: 'older', state: 'healthy', created: '2024-12-06 19:07:17 +0000 WET' },
+      { name: 'newer', state: 'healthy', created: '2025-07-01 13:00:00 +0100 WEST' },
+    ]
+    sortVolume(volumes)
+    expect(volumes.map(v => v.name)).toEqual(['newer', 'older'])
   })
 })

--- a/src/utils/formatDate.js
+++ b/src/utils/formatDate.js
@@ -1,24 +1,16 @@
 import React from 'react'
 import moment from 'moment'
 import { Tooltip } from 'antd'
-
-function utcStrToDate(utcStr) {
-  const reg = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}) \+\d{4} UTC$/
-  const results = utcStr.match(reg)
-  if (results && results.length === 3) {
-    const d = results[1].split('-').map(item => parseInt(item, 10))
-    const t = results[2].split(':').map(item => parseInt(item, 10))
-    return new Date(Date.UTC(d[0], d[1] - 1, d[2], t[0], t[1], t[2]))
-  }
-  return utcStr
-}
+import { utcStrToDate } from './formatter'
 
 export function formatDate(date, hasTooltip = true) {
   // Initial date return null
   if (date === '0001-01-01 00:00:00 +0000 UTC' || !date) {
     return ''
   }
-  let gmt = utcStrToDate(date)
+  const parsed = utcStrToDate(date)
+  // Other formats (e.g. RFC3339) are left to moment
+  const gmt = parsed instanceof Date ? parsed : date
   if (hasTooltip) {
     return <Tooltip title={`${moment(gmt).utc().format()}`}>
       {moment(gmt).fromNow()}

--- a/src/utils/formatter.js
+++ b/src/utils/formatter.js
@@ -53,13 +53,17 @@ export function formatSize(selected, unit = 'Gi') {
   return 0
 }
 
+// Parses Go time.Time.String() output, e.g. "2024-12-06 19:07:17 +0000 UTC".
+// The zone abbreviation depends on the manager's timezone (WET, CET, +03, ...),
+// so only the numeric offset is used.
 export function utcStrToDate(utcStr) {
-  const reg = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}) \+\d{4} UTC$/
+  const reg = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}) ([+-])(\d{2})(\d{2}) \S+$/
   const results = utcStr.match(reg)
-  if (results && results.length === 3) {
+  if (results && results.length === 6) {
     const d = results[1].split('-').map(item => parseInt(item, 10))
     const t = results[2].split(':').map(item => parseInt(item, 10))
-    return new Date(Date.UTC(d[0], d[1] - 1, d[2], t[0], t[1], t[2]))
+    const offsetMinutes = (results[3] === '-' ? -1 : 1) * (parseInt(results[4], 10) * 60 + parseInt(results[5], 10))
+    return new Date(Date.UTC(d[0], d[1] - 1, d[2], t[0], t[1] - offsetMinutes, t[2]))
   }
   return 'Invalid UTC Date'
 }


### PR DESCRIPTION
### What this PR does / why we need it

## Problem

With `global.timezone` set to a non-UTC zone (the report uses `Atlantic/Madeira`), the Volumes page shows `Invalid date` in the `Created` column for every volume, and the browser console logs the moment fallback deprecation warning for values like `2024-12-06 19:07:17 +0000 WET`.

## Root cause

longhorn-manager fills `Volume.Created` with `v.CreationTimestamp.String()` (`api/model.go`), i.e. Go `time.Time.String()`: `2006-01-02 15:04:05 -0700 MST`. The zone suffix follows the manager's timezone, so it is `+0000 WET` in winter and `+0100 WEST` in summer for Madeira, `+0100 CET` for central Europe, and so on.

The UI parser only accepts the literal `+0000 UTC` suffix:

- `src/utils/formatter.js:57` – `utcStrToDate()` regex `/^... \+\d{4} UTC$/`; on a mismatch it returns the string `'Invalid UTC Date'`, which `sortVolume()` (`src/utils/sort.js:43`) then calls `.getTime()` on, throwing a `TypeError`.
- `src/utils/formatDate.js:6` – a private copy of the same function with the same regex; on a mismatch it hands the raw string to moment, which cannot parse it and renders `Invalid date`.

## Fix

- `utcStrToDate()` now matches `YYYY-MM-DD HH:mm:ss [+-]hhmm ZONE` for any zone token and applies the numeric offset when building the `Date`, so `2024-12-06 20:07:17 +0100 CET` and `2024-12-06 19:07:17 +0000 WET` both resolve to `2024-12-06T19:07:17Z`. The zone token is matched with `\S+` rather than `[A-Z]+` because Go prints zones without an abbreviation as e.g. `+03`.
- `formatDate.js` drops its duplicate and reuses the exported `utcStrToDate()`; non-matching input (RFC3339 fields such as `lastBackupAt`) is still passed through to moment unchanged.
- Return value for non-matching input (`'Invalid UTC Date'`) is unchanged.

### Issue

https://github.com/longhorn/longhorn/issues/13140

### Test Result

## How tested

Added `src/utils/__tests__/formatter.js` (UTC, zero-offset WET, positive/negative offsets, zone without abbreviation, non-matching formats) and a `sortVolume` case in `src/utils/__tests__/sort.js`.

Before the fix (`npx jest src/utils/__tests__`):

```
FAIL src/utils/__tests__/sort.js
  ● sort › sortVolume should order by created time regardless of zone abbreviation
    TypeError: (0 , _formatter.utcStrToDate)(...).getTime is not a function
      at sort (src/utils/sort.js:43:38)

FAIL src/utils/__tests__/formatter.js
  ● utcStrToDate › should parse a zero-offset timestamp with a non-UTC zone abbreviation
    Expected: 2024-12-06T19:07:17.000Z
    Received: "Invalid UTC Date"
  ● utcStrToDate › should apply a positive offset
  ● utcStrToDate › should apply a negative offset
  ● utcStrToDate › should parse a zone without an alphabetic abbreviation

Tests:       5 failed, 3 passed, 8 total
```

After the fix (`npx jest`):

```
PASS src/utils/__tests__/formatter.js
PASS src/utils/__tests__/sort.js
Tests:       8 passed, 8 total
```

`npx eslint --ext .js src/utils` is clean and `npm run build` succeeds. Not verified against a live cluster with a non-UTC `global.timezone`; the input strings in the tests are taken from the issue report and from Go `time.String()` formatting.

### Additional documentation or context

## Links

- Issue: https://github.com/longhorn/longhorn/issues/13140
- Manager field: https://github.com/longhorn/longhorn-manager/blob/master/api/model.go (`Created: v.CreationTimestamp.String()`)

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.
