### PR TITLE
feat(ui): add dynamic favicon badge for cluster state

### DIFF
--- a/src/routes/dashboard/index.js
+++ b/src/routes/dashboard/index.js
@@ -1,12 +1,17 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'dva'
 import queryString from 'query-string'
 import { Card } from 'antd'
 import { routerRedux } from 'dva/router'
 import { ResourceOverview, EventLogs } from './components'
+import { updateFavicon } from '../../utils/favicon'
 
 function Dashboard({ host, volume, eventlog, loading, dispatch, location }) {
+  useEffect(() => {
+    updateFavicon(host, volume)
+  }, [host && host.data, volume && volume.data])
+
   let { data: eventlogsData, sorter } = eventlog
   let eventlogs = eventlogsData.map((item) => {
     let obj = {}

--- a/src/utils/favicon.js
+++ b/src/utils/favicon.js
@@ -1,0 +1,90 @@
+import {
+  faultedVolume,
+  degradedVolume,
+  inProgressVolume,
+  downNode,
+  unschedulableNode,
+  autoEvictingNode,
+} from './filter'
+
+const ERROR_COLOR = '#F15354'
+const WARNING_COLOR = '#F1C40F'
+const HEALTHY_COLOR = '#27AE5F'
+
+const ICON_SIZE = 64
+const BORDER_COLOR = '#FFFFFF'
+
+export function getClusterState(host, volume) {
+  const hosts = (host && host.data) || []
+  const volumes = (volume && volume.data) || []
+  if (faultedVolume(volumes).length > 0 || downNode(hosts).length > 0) {
+    return { color: ERROR_COLOR, state: 'error' }
+  }
+  if (degradedVolume(volumes).length > 0
+    || inProgressVolume(volumes).length > 0
+    || unschedulableNode(hosts).length > 0
+    || autoEvictingNode(hosts).length > 0) {
+    return { color: WARNING_COLOR, state: 'warning' }
+  }
+  return { color: HEALTHY_COLOR, state: 'healthy' }
+}
+
+function createBadgeCanvas(image, color) {
+  const canvas = document.createElement('canvas')
+  canvas.width = ICON_SIZE
+  canvas.height = ICON_SIZE
+  const ctx = canvas.getContext('2d')
+  if (image) {
+    ctx.drawImage(image, 0, 0, canvas.width, canvas.height)
+  }
+  // Draw the badge at the bottom-right corner with a small white border
+  const radius = ICON_SIZE * 0.2
+  const cx = canvas.width - radius - ICON_SIZE * 0.08
+  const cy = canvas.height - radius - ICON_SIZE * 0.08
+  ctx.beginPath()
+  ctx.arc(cx, cy, radius, 0, Math.PI * 2)
+  ctx.fillStyle = color
+  ctx.fill()
+  ctx.lineWidth = Math.max(1, ICON_SIZE * 0.05)
+  ctx.strokeStyle = BORDER_COLOR
+  ctx.stroke()
+  return canvas.toDataURL()
+}
+
+function applyFavicon(dataUrl) {
+  let link = document.querySelector('link[rel="icon"]')
+  if (!link) {
+    link = document.createElement('link')
+    link.rel = 'icon'
+    document.head.appendChild(link)
+  }
+  link.href = dataUrl
+}
+
+let cachedFaviconImage = null
+let cachedClusterState = null
+
+export function updateFavicon(host, volume) {
+  const { color, state } = getClusterState(host, volume)
+  // Skip redrawing when the cluster state has not changed
+  if (state === cachedClusterState) {
+    return
+  }
+  cachedClusterState = state
+
+  if (cachedFaviconImage) {
+    applyFavicon(createBadgeCanvas(cachedFaviconImage, color))
+    return
+  }
+
+  const image = new Image()
+  image.onload = () => {
+    cachedFaviconImage = image
+    applyFavicon(createBadgeCanvas(image, color))
+  }
+  // Fallback to a solid-color badge icon if the favicon fails to load
+  image.onerror = () => {
+    applyFavicon(createBadgeCanvas(null, color))
+  }
+  image.src = '/favicon.ico'
+}

--- a/src/utils/favicon.test.js
+++ b/src/utils/favicon.test.js
@@ -1,0 +1,102 @@
+import { getClusterState } from './favicon'
+import { faultedVolume, degradedVolume, inProgressVolume, detachedVolume } from './filter'
+
+const healthyVolume = { state: 'attached', robustness: 'healthy' }
+const degradedVol = { state: 'attached', robustness: 'degraded' }
+const inProgressVol = { state: 'attached', robustness: 'creating' }
+const faultedVol = { state: 'detached', robustness: 'faulted' }
+const detachedVol = { state: 'detached', robustness: 'healthy' }
+
+const healthyHost = {
+  allowScheduling: true,
+  conditions: {
+    Ready: { status: 'True' },
+    Schedulable: { status: 'True' },
+  },
+  disks: {
+    'disk-1': {
+      allowScheduling: true,
+      conditions: {
+        Ready: { status: 'True' },
+        Schedulable: { status: 'True' },
+      },
+    },
+  },
+}
+
+const clone = (obj) => JSON.parse(JSON.stringify(obj))
+
+const downHost = () => {
+  const host = clone(healthyHost)
+  host.conditions.Ready.status = 'False'
+  return host
+}
+
+const unschedulableHost = () => {
+  const host = clone(healthyHost)
+  host.conditions.Schedulable.status = 'False'
+  return host
+}
+
+const autoEvictingHost = () => {
+  const host = unschedulableHost()
+  host.autoEvicting = true
+  return host
+}
+
+const hosts = (list) => ({ data: list })
+const volumes = (list) => ({ data: list })
+
+describe('getClusterState', () => {
+  it('returns healthy when all volumes and nodes are fine', () => {
+    const state = getClusterState(hosts([clone(healthyHost)]), volumes([clone(healthyVolume)]))
+    expect(state).toEqual({ color: '#27AE5F', state: 'healthy' })
+  })
+
+  it('returns healthy when there is no data', () => {
+    expect(getClusterState(hosts([]), volumes([]))).toEqual({ color: '#27AE5F', state: 'healthy' })
+    expect(getClusterState(null, null)).toEqual({ color: '#27AE5F', state: 'healthy' })
+  })
+
+  it('returns warning when a volume is degraded', () => {
+    const state = getClusterState(hosts([clone(healthyHost)]), volumes([clone(degradedVol)]))
+    expect(state).toEqual({ color: '#F1C40F', state: 'warning' })
+  })
+
+  it('returns warning when a volume is in progress', () => {
+    const state = getClusterState(hosts([clone(healthyHost)]), volumes([clone(inProgressVol)]))
+    expect(state).toEqual({ color: '#F1C40F', state: 'warning' })
+  })
+
+  it('returns warning when a node is unschedulable or auto-evicting', () => {
+    expect(getClusterState(hosts([clone(healthyHost), unschedulableHost()]), volumes([clone(healthyVolume)])))
+      .toEqual({ color: '#F1C40F', state: 'warning' })
+    expect(getClusterState(hosts([clone(healthyHost), autoEvictingHost()]), volumes([clone(healthyVolume)])))
+      .toEqual({ color: '#F1C40F', state: 'warning' })
+  })
+
+  it('returns error when a volume is faulted', () => {
+    const state = getClusterState(hosts([clone(healthyHost)]), volumes([clone(faultedVol)]))
+    expect(state).toEqual({ color: '#F15354', state: 'error' })
+  })
+
+  it('returns error when a node is down', () => {
+    const state = getClusterState(hosts([clone(healthyHost), downHost()]), volumes([clone(healthyVolume)]))
+    expect(state).toEqual({ color: '#F15354', state: 'error' })
+  })
+
+  it('returns error when both a faulted volume and a down node exist', () => {
+    const state = getClusterState(hosts([downHost()]), volumes([clone(faultedVol), clone(degradedVol)]))
+    expect(state).toEqual({ color: '#F15354', state: 'error' })
+  })
+
+  it('ignores detached volumes', () => {
+    const vols = [clone(detachedVol), { state: 'detached', robustness: 'degraded' }]
+    expect(detachedVolume(vols)).toHaveLength(2)
+    expect(faultedVolume(vols)).toHaveLength(0)
+    expect(degradedVolume(vols)).toHaveLength(0)
+    expect(inProgressVolume(vols)).toHaveLength(0)
+    expect(getClusterState(hosts([clone(healthyHost)]), volumes(vols)))
+      .toEqual({ color: '#27AE5F', state: 'healthy' })
+  })
+})


### PR DESCRIPTION
This PR updates the browser tab favicon with a small colored badge that shows the current cluster state, so users can see at a glance when a node or volume needs attention without keeping the Longhorn tab focused.

- Green: all volumes and nodes are healthy.
- Yellow: at least one volume is degraded/in-progress or a node is unschedulable/auto-evicting.
- Red: at least one volume is faulted or a node is down.

Detached volumes are ignored when determining the badge color, matching the request in the issue.

Changes:
- Added src/utils/favicon.js with helpers to compute the cluster state and update the favicon.
- Wired the favicon update into the Dashboard component so it reacts to host/volume data changes.
- Added unit tests in src/utils/favicon.test.js.

Closes longhorn/longhorn#12463

Signed-off-by: Sakthi Harish <sakthi.harish@edgeverve.com>